### PR TITLE
settings activity

### DIFF
--- a/Branch-SDK-TestBed/AndroidManifest.xml
+++ b/Branch-SDK-TestBed/AndroidManifest.xml
@@ -45,6 +45,8 @@
 
         <activity android:name="io.branch.branchandroiddemo.CreditHistoryActivity"/>
 
+        <activity android:name="io.branch.branchandroiddemo.SettingsActivity"/>
+
         <activity android:name="io.branch.branchandroiddemo.ReferralCodeActivity"/>
 
         <activity android:name=".AutoDeepLinkTestActivity">

--- a/Branch-SDK-TestBed/res/layout/activity_settings.xml
+++ b/Branch-SDK-TestBed/res/layout/activity_settings.xml
@@ -1,0 +1,113 @@
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="20dp">
+
+<RelativeLayout
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText
+        android:id="@+id/editBranchKey"
+        android:layout_width="match_parent"
+        android:layout_height="40dp"
+        android:textSize="14sp"
+        android:gravity="center"
+        android:hint="branch key"
+        />
+
+    <Button
+        android:id="@+id/cmdSetBranchKey"
+        android:layout_width="180dp"
+        android:layout_height="40dp"
+        android:layout_centerHorizontal="true"
+        android:layout_below="@+id/editBranchKey"
+        android:text="Save"
+        android:textAppearance="@android:style/TextAppearance.Small"
+        android:textColor="@android:color/white"
+        />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:id="@+id/keyValueLin"
+        android:layout_below="@+id/cmdSetBranchKey">
+
+    <EditText
+        android:id="@+id/editKey"
+        android:layout_width="0dp"
+        android:layout_weight="1"
+        android:layout_height="40dp"
+        android:layout_centerHorizontal="true"
+        android:textSize="14sp"
+        android:gravity="center"
+        android:hint="debug key"
+        android:singleLine="true"
+        android:nextFocusDown="@+id/editValue"/>
+
+    <EditText
+        android:id="@+id/editValue"
+        android:layout_width="0dp"
+        android:layout_weight="1"
+        android:layout_height="40dp"
+        android:textSize="14sp"
+        android:gravity="center"
+        android:hint="debug value"
+        android:layout_below="@+id/editKey"
+        android:singleLine="true"
+        android:imeOptions="actionDone"
+        />
+
+    </LinearLayout>
+
+    <Button
+        android:id="@+id/cmdSetDebugValue"
+        android:layout_width="180dp"
+        android:layout_height="40dp"
+        android:layout_centerHorizontal="true"
+        android:layout_below="@+id/keyValueLin"
+        android:text="Add"
+        android:textAppearance="@android:style/TextAppearance.Small"
+        android:textColor="@android:color/white"
+        />
+
+    <TextView
+        android:id="@+id/txtDebugKeyValues"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:padding="5dp"
+        android:hint="debug key : debug value"
+        android:layout_below="@+id/cmdSetDebugValue"
+        android:textColor="@android:color/white"
+        android:gravity="center"
+        />
+
+    <Button
+        android:id="@+id/cmdClearSettings"
+        android:layout_width="180dp"
+        android:layout_height="40dp"
+        android:layout_centerHorizontal="true"
+        android:layout_below="@+id/txtDebugKeyValues"
+        android:text="Clear Settings"
+        android:textAppearance="@android:style/TextAppearance.Small"
+        android:textColor="@android:color/white"
+        />
+
+    <TextView
+        android:id="@+id/txtRewardBalance"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:padding="5dp"
+        android:text="credits = "
+        android:layout_below="@+id/cmdRefreshShortURL"
+        android:textColor="@android:color/white"
+        android:visibility="gone"/>
+
+</RelativeLayout>
+
+ </ScrollView>

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
@@ -296,6 +296,16 @@ public class MainActivity extends Activity {
             }
         });
 
+        findViewById(R.id.share_btn).setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View v) {
+                Log.i("BranchTestBed", "Loading settings...");
+                Intent i = new Intent(getApplicationContext(), SettingsActivity.class);
+                startActivity(i);
+                return true;
+            }
+        });
+
         // Add optional deep link debug params
         //        try {
         //            JSONObject debugObj = new JSONObject();

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.EditText;
@@ -30,6 +31,9 @@ public class MainActivity extends Activity {
     TextView txtRewardBalance;
 
     BranchUniversalObject branchUniversalObject;
+
+    int count = 0;
+    long startMillis = 0;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -296,16 +300,6 @@ public class MainActivity extends Activity {
             }
         });
 
-        findViewById(R.id.share_btn).setOnLongClickListener(new View.OnLongClickListener() {
-            @Override
-            public boolean onLongClick(View v) {
-                Log.i("BranchTestBed", "Loading settings...");
-                Intent i = new Intent(getApplicationContext(), SettingsActivity.class);
-                startActivity(i);
-                return true;
-            }
-        });
-
         // Add optional deep link debug params
         //        try {
         //            JSONObject debugObj = new JSONObject();
@@ -364,4 +358,29 @@ public class MainActivity extends Activity {
             startActivity(i);
         }
     }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        int eventaction = event.getAction();
+        if (eventaction == MotionEvent.ACTION_UP) {
+
+            long time = System.currentTimeMillis();
+
+            if (startMillis == 0 || (time - startMillis > 3000)) {
+                startMillis = time;
+                count = 1;
+            }
+            else {
+                count++;
+            }
+
+            if (count == 5) {
+                Intent i = new Intent(getApplicationContext(), SettingsActivity.class);
+                startActivity(i);
+            }
+            return true;
+        }
+        return false;
+    }
+
 }

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/SettingsActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/SettingsActivity.java
@@ -1,0 +1,146 @@
+package io.branch.branchandroiddemo;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.util.Log;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.widget.EditText;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Iterator;
+
+import io.branch.referral.Branch;
+import io.branch.referral.PrefHelper;
+
+public class SettingsActivity extends Activity {
+    Branch branch;
+    EditText txtDeepKey;
+    EditText txtDeepValue;
+    EditText txtEditBranchKey;
+    PrefHelper prefHelper;
+    TextView txtDebugKeyValues;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_settings);
+        prefHelper = PrefHelper.getInstance(this);
+
+        txtEditBranchKey = (EditText) findViewById(R.id.editBranchKey);
+        txtDeepKey = (EditText) findViewById(R.id.editKey);
+        txtDeepValue = (EditText) findViewById(R.id.editValue);
+        txtDebugKeyValues = (TextView) findViewById(R.id.txtDebugKeyValues);
+
+        if (!TextUtils.isEmpty(prefHelper.getBranchKey())) {
+            txtEditBranchKey.setText(prefHelper.getBranchKey());
+        }
+
+        txtDeepValue.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+            @Override
+            public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+                boolean handled = false;
+                if (actionId == EditorInfo.IME_ACTION_DONE) {
+                    setDeepLinkDebugData();
+                    handled = true;
+                }
+                return handled;
+            }
+        });
+
+        findViewById(R.id.cmdSetBranchKey).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (!TextUtils.isEmpty(txtEditBranchKey.getText().toString().trim())) {
+                    prefHelper.setBranchKey(txtEditBranchKey.getText().toString().trim());
+                    Toast.makeText(getApplicationContext(), "Saved Key", Toast.LENGTH_LONG).show();
+                }
+            }
+        });
+
+        findViewById(R.id.cmdSetDebugValue).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                setDeepLinkDebugData();
+            }
+        });
+
+        findViewById(R.id.cmdClearSettings).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                prefHelper.setBranchKey("");
+                Branch.getInstance().setDeepLinkDebugMode(null);
+                txtDebugKeyValues.setText("");
+                Toast.makeText(getApplicationContext(), "Cleared Settings", Toast.LENGTH_LONG).show();
+            }
+        });
+
+        fillDebugParams();
+    }
+
+    private void setDeepLinkDebugData() {
+        if (TextUtils.isEmpty(txtDeepKey.getText().toString().trim()) || TextUtils.isEmpty(txtDeepValue.getText().toString().trim())) {
+            Toast.makeText(getApplicationContext(), "Add debug Key/Value failed -- empty string(s)", Toast.LENGTH_LONG).show();
+            return;
+        }
+
+        JSONException jsonException = null;
+        try {
+            JSONObject debugObj = new JSONObject();
+            debugObj.put(txtDeepKey.getText().toString().trim(), txtDeepValue.getText().toString().trim());
+
+            //should we make appendDebugParams (Branch.java) public?
+            JSONObject currentDebugParams = Branch.getInstance().getDeeplinkDebugParams();
+            if (currentDebugParams != null) {
+                currentDebugParams.put(txtDeepKey.getText().toString().trim(), txtDeepValue.getText().toString().trim());
+                Branch.getInstance().setDeepLinkDebugMode(currentDebugParams);
+            } else {
+                Branch.getInstance().setDeepLinkDebugMode(debugObj);
+            }
+
+        } catch (JSONException ignore) {
+            jsonException = ignore;
+            Toast.makeText(getApplicationContext(), "Add debug Key/Value failed", Toast.LENGTH_LONG).show();
+        } finally {
+            if (jsonException == null) {
+                String addText = txtDeepKey.getText().toString().trim() + " : " + txtDeepValue.getText().toString().trim() + "\n";
+                txtDebugKeyValues.append(addText);
+                txtDeepKey.setText("");
+                txtDeepValue.setText("");
+                txtDeepKey.requestFocus();
+            }
+        }
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        branch = Branch.getInstance();
+    }
+
+    private void fillDebugParams() {
+        JSONObject debugKeyValues = Branch.getInstance().getDeeplinkDebugParams();
+        if (debugKeyValues != null) {
+            txtDebugKeyValues.setText("");
+            for (Iterator<String> iter = debugKeyValues.keys(); iter.hasNext(); ) {
+                String key = iter.next();
+                try {
+                    String value = (String) debugKeyValues.get(key);
+                    if (!TextUtils.isEmpty(key) && !TextUtils.isEmpty(value)) {
+                        String addText = key + " : " + value + "\n";
+                        txtDebugKeyValues.append(addText);
+                        Log.d("Debug", "adding: " + addText);
+                    }
+                } catch (JSONException e) {
+
+                }
+            }
+        }
+    }
+}

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/SettingsActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/SettingsActivity.java
@@ -74,7 +74,8 @@ public class SettingsActivity extends Activity {
         findViewById(R.id.cmdClearSettings).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                prefHelper.setBranchKey("");
+                prefHelper.setBranchKey(prefHelper.getBranchKey());
+                txtEditBranchKey.setText(prefHelper.getBranchKey());
                 Branch.getInstance().setDeepLinkDebugMode(null);
                 txtDebugKeyValues.setText("");
                 Toast.makeText(getApplicationContext(), "Cleared Settings", Toast.LENGTH_LONG).show();

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/SettingsActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/SettingsActivity.java
@@ -1,6 +1,9 @@
 package io.branch.branchandroiddemo;
 
 import android.app.Activity;
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
@@ -74,8 +77,9 @@ public class SettingsActivity extends Activity {
         findViewById(R.id.cmdClearSettings).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                prefHelper.setBranchKey(prefHelper.getBranchKey());
-                txtEditBranchKey.setText(prefHelper.getBranchKey());
+                prefHelper.setBranchKey(null);
+                prefHelper.setBranchKey(prefHelper.readBranchKey(!isTestModeEnabled(getApplicationContext())));
+                txtEditBranchKey.setText(prefHelper.readBranchKey(!isTestModeEnabled(getApplicationContext())));
                 Branch.getInstance().setDeepLinkDebugMode(null);
                 txtDebugKeyValues.setText("");
                 Toast.makeText(getApplicationContext(), "Cleared Settings", Toast.LENGTH_LONG).show();
@@ -141,5 +145,20 @@ public class SettingsActivity extends Activity {
                 }
             }
         }
+    }
+
+    private boolean isTestModeEnabled(Context context) {
+        boolean isTestMode_ = false;
+        String testModeKey = "io.branch.sdk.TestMode";
+        try {
+            final ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+            if (ai.metaData != null) {
+                isTestMode_ = ai.metaData.getBoolean(testModeKey, false);
+            }
+        } catch (final PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        }
+
+        return isTestMode_;
     }
 }

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/SettingsActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/SettingsActivity.java
@@ -128,7 +128,6 @@ public class SettingsActivity extends Activity {
     private void fillDebugParams() {
         JSONObject debugKeyValues = Branch.getInstance().getDeeplinkDebugParams();
         if (debugKeyValues != null) {
-            txtDebugKeyValues.setText("");
             for (Iterator<String> iter = debugKeyValues.keys(); iter.hasNext(); ) {
                 String key = iter.next();
                 try {
@@ -136,7 +135,6 @@ public class SettingsActivity extends Activity {
                     if (!TextUtils.isEmpty(key) && !TextUtils.isEmpty(value)) {
                         String addText = key + " : " + value + "\n";
                         txtDebugKeyValues.append(addText);
-                        Log.d("Debug", "adding: " + addText);
                     }
                 } catch (JSONException e) {
 


### PR DESCRIPTION
@sojanpr 

Added settings activity (long press "Share Link" to launch activity)

Allows you to set Branch Key w/ UI.
Allows you to set deeplinkdebug params w/ UI.

UI auto populates currently set debugparams when killing/re-entering activity. I also included "next" and "enter" functionality to make adding debugparams a friendly experience. Press Enter after typing in a key -> focus goes to next edittext, press enter and both edittexts clear + the debugparams are set, and focus goes back to original edittext.

Current blocker: I thought that calling setBranchKey("") would cause app to use original Branch Key from XML file, but it does not. If you set an empty Branch Key (using PrefHelper) and exit->enter app, app is still using empty String. If you set an empty Branch Key (using PrefHelper) and exit to main activity, app is still using empty String and not original XML String.
