### PR TITLE
Better Deferred Init Callback

### DIFF
--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -30,6 +30,7 @@ public abstract class ServerRequest {
     private SystemObserver systemObserver_;
     long queueWaitTime_ = 0;
     private boolean disableAndroidIDFetch_;
+    private boolean isWaitLockEnabled_;
 
     /*True if there is an error in creating this request such as error with json parameters.*/
     public boolean constructError_ = false;
@@ -425,5 +426,24 @@ public abstract class ServerRequest {
             waitTime = System.currentTimeMillis() - queueWaitTime_;
         }
         return waitTime;
+    }
+
+    /**
+     * Set a wait lock before processing this request. Setting true will wait processing this request
+     * from the request queue.
+     *
+     * @param enable {@link Boolean} with true to enable the request process wait lock else false
+     */
+    public void setProcessWaitLockEnabled(boolean enable) {
+        isWaitLockEnabled_ = enable;
+    }
+
+    /**
+     * Check if this request is waiting on any operation to finish before processing
+     *
+     * @return True if this request if any pre processing operation pending
+     */
+    public boolean isProcessWaitLockEnabled() {
+        return isWaitLockEnabled_;
     }
 }

--- a/Branch-SDK/src/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestInitSession.java
@@ -70,4 +70,14 @@ abstract class ServerRequestInitSession extends ServerRequest {
         }
         return isBranchViewShowing;
     }
+
+    public void updateLinkClickIdentifier() {
+        if (!prefHelper_.getLinkClickIdentifier().equals(PrefHelper.NO_STRING_VALUE)) {
+            try {
+                getPost().put(Defines.Jsonkey.LinkIdentifier.getKey(), prefHelper_.getLinkClickIdentifier());
+            } catch (JSONException ignore) {
+            }
+        }
+    }
+
 }

--- a/Branch-SDK/src/io/branch/referral/ServerRequestQueue.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestQueue.java
@@ -350,4 +350,25 @@ class ServerRequestQueue {
             }
         }
     }
+
+    /**
+     * Set Process wait lock to false for any open / install request in the queue
+     */
+    public void unlockInstallOrOpenProcessWait() {
+        synchronized (queue) {
+            Iterator<ServerRequest> iter = queue.iterator();
+            while (iter.hasNext()) {
+                ServerRequest req = iter.next();
+                if (req != null) {
+                    if (req instanceof ServerRequestRegisterInstall) {
+                        req.setProcessWaitLockEnabled(false);
+                    } else if (req instanceof ServerRequestRegisterOpen) {
+                        req.setProcessWaitLockEnabled(false);
+                    }
+                }
+            }
+        }
+    }
+
+
 }

--- a/Branch-SDK/src/io/branch/referral/ServerRequestQueue.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestQueue.java
@@ -360,9 +360,7 @@ class ServerRequestQueue {
             while (iter.hasNext()) {
                 ServerRequest req = iter.next();
                 if (req != null) {
-                    if (req instanceof ServerRequestRegisterInstall) {
-                        req.setProcessWaitLockEnabled(false);
-                    } else if (req instanceof ServerRequestRegisterOpen) {
+                    if (req instanceof ServerRequestRegisterInstall || req instanceof ServerRequestRegisterOpen) {
                         req.setProcessWaitLockEnabled(false);
                     }
                 }


### PR DESCRIPTION
Implementation for handling a delayed request processing due to any
async operation waiting to finish before processing  the request.

Tested with cases
1. InitSession called form `oncrease` or `onStart`
2.Init session with `BUO ReferralCallback` and `BranchReferralcallback`

3.Custom events added before and after init session

4.BMF with FB app link fetch

@aaustin @Sarkar @EvangelosG 
