### PR TITLE
Improved Branch request handling in slow network

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -603,7 +603,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents {
      *                   up and declaring defeat.
      */
     public void setRetryCount(int retryCount) {
-        if (prefHelper_ != null && retryCount > 0) {
+        if (prefHelper_ != null && retryCount >= 0) {
             prefHelper_.setRetryCount(retryCount);
         }
     }

--- a/Branch-SDK/src/io/branch/referral/RemoteInterface.java
+++ b/Branch-SDK/src/io/branch/referral/RemoteInterface.java
@@ -15,11 +15,17 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.Iterator;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSession;
 
 /**
  * <p>This class assists with RESTful calls to the Branch API, by using
@@ -152,7 +158,7 @@ class RemoteInterface {
     private ServerResponse make_restful_get(String baseUrl, JSONObject params, String tag, int timeout, int retryNumber, boolean log) {
         String modifiedUrl = baseUrl;
         JSONObject getParameters = new JSONObject();
-        HttpURLConnection connection = null;
+        HttpsURLConnection connection = null;
         if (timeout <= 0) {
             timeout = DEFAULT_TIMEOUT;
         }
@@ -173,13 +179,22 @@ class RemoteInterface {
         }
 
         try {
+            modifiedUrl = getResolvedApiUrl(modifiedUrl);
             if (log) PrefHelper.Debug("BranchSDK", "getting " + modifiedUrl);
             lastRoundTripTime_ = 0;
             long reqStartTime = System.currentTimeMillis();
             URL urlObject = new URL(modifiedUrl);
-            connection = (HttpURLConnection) urlObject.openConnection();
+            connection = (HttpsURLConnection) urlObject.openConnection();
             connection.setConnectTimeout(timeout);
             connection.setReadTimeout(timeout);
+            // Default host verifier will provide SSL error on host verification since ip used in request is not mapped to a certificate
+            connection.setHostnameVerifier(new HostnameVerifier() {
+                @Override
+                public boolean verify(String hostname, SSLSession session) {
+                    return true; // intentionally skipping host verification here
+                }
+            });
+
             lastRoundTripTime_ = (int) (System.currentTimeMillis() - reqStartTime);
             if (Branch.getInstance() != null) {
                 Branch.getInstance().addExtraInstrumentationData(tag + "-" + Defines.Jsonkey.Last_Round_Trip_Time.getKey(), String.valueOf(lastRoundTripTime_));
@@ -294,7 +309,7 @@ class RemoteInterface {
      */
     private ServerResponse make_restful_post(JSONObject body, String url, String tag, int timeout,
                                              int retryNumber, boolean log) {
-        HttpURLConnection connection = null;
+        HttpsURLConnection connection = null;
         if (timeout <= 0) {
             timeout = DEFAULT_TIMEOUT;
         }
@@ -314,12 +329,13 @@ class RemoteInterface {
             if (!addCommonParams(bodyCopy, retryNumber)) {
                 return new ServerResponse(tag, NO_BRANCH_KEY_STATUS);
             }
+            url = getResolvedApiUrl(url);
             if (log) {
                 PrefHelper.Debug("BranchSDK", "posting to " + url);
                 PrefHelper.Debug("BranchSDK", "Post value = " + bodyCopy.toString(4));
             }
             URL urlObject = new URL(url);
-            connection = (HttpURLConnection) urlObject.openConnection();
+            connection = (HttpsURLConnection) urlObject.openConnection();
             connection.setConnectTimeout(timeout);
             connection.setReadTimeout(timeout);
             connection.setDoInput(true);
@@ -327,6 +343,15 @@ class RemoteInterface {
             connection.setRequestProperty("Content-Type", "application/json");
             connection.setRequestProperty("Accept", "application/json");
             connection.setRequestMethod("POST");
+
+            // Default host verifier will provide SSL error on host verification since ip used in request is not mapped to a certificate
+            connection.setHostnameVerifier(new HostnameVerifier() {
+                @Override
+                public boolean verify(String hostname, SSLSession session) {
+                    return true; // intentionally skipping host verification here
+                }
+            });
+
 
             lastRoundTripTime_ = 0;
             long reqStartTime = System.currentTimeMillis();
@@ -430,5 +455,19 @@ class RemoteInterface {
         }
 
         return result.toString();
+    }
+
+
+    private String getResolvedApiUrl( String url) throws MalformedURLException, UnknownHostException {
+        // If the hostname resolves to multiple IP addresses, URL connection will attempt to connect the next if one connection fails
+        // This may result is multiple timeouts elapse before the connect attempt throws an exception. In order to make sure the
+        // Branch callback is called with in the timeout specified we resolve the host first and then try only with first resolved ip
+
+        String apiHost = new URL(url).getHost();
+        InetAddress inetAddress = InetAddress.getByName(apiHost);
+        if (inetAddress != null && inetAddress.getHostAddress() != null) {
+            url = url.replace(apiHost, inetAddress.getHostAddress());
+        }
+        return url;
     }
 }


### PR DESCRIPTION
On slow networks If the hostname resolves to multiple IP addresses, URL
connection will attempt to connect the next if one connection fails.
This may result is multiple timeouts elapse before the connect attempt
throws an exception. In order to make sure the Branch callback is
called with in the timeout specified we resolve the host first and then
try only with first resolved ip.
This will ensure that Branch Callbacks are retuned in the time out
specified (Default is 3sec sec and 3 attempts. so 9 sec max).
This fix will solve the issue “Branch init callback returned after
long wait on slow networks”

@aaustin @Sarkar @EvangelosG @hubt 