### PR TITLE
Increase retry interval to 1 s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ gen/
 Branch-SDK-TestBed/gradle/wrapper/gradle-wrapper.jar
 Branch-SDK-TestBed/gradlew
 Branch-SDK-TestBed/gradlew.bat
+
+Branch-SDK-TestBed/gradle/wrapper/gradle-wrapper.properties

--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -43,7 +43,8 @@ public class PrefHelper {
      */
     public static final String NO_STRING_VALUE = "bnc_no_value";
 
-    private static final int INTERVAL_RETRY = 0;
+    // We should keep this non-zero to give the connection time to recover after a failure
+    private static final int INTERVAL_RETRY = 1000;
 
     /**
      * Number of times to reattempt connection to the Branch server before giving up and throwing an


### PR DESCRIPTION
There are reports of high client timeout errors despite impeccable
server performance. I have a hypothesis that by not waiting some time
between retries, we don’t give the connection time to recover,
therefore rendering the retry code useless. I don’t see how else with 3
retries we’d have the same timeout issues.

@sojanpr