### PR TITLE
Adding answers-shim from Maven

### DIFF
--- a/Branch-SDK/build.gradle
+++ b/Branch-SDK/build.gradle
@@ -6,7 +6,7 @@ def jarFileName
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
     compile 'com.android.support:support-annotations:22.2.0'
-    compile ('com.crashlytics.sdk.android:answers-shim:0.0.3@aar')
+    compile 'io.branch.external.answersshim:answers-shim:0.0.3@aar'
 }
 
 android {


### PR DESCRIPTION
Answers shim 0.0.3 is added to maven and using with Branch SDK to get
rid off jcenter dependency.
This would be changed when Answers-Shim is available on both maven and
center

@aaustin @stevewilber 