### PR TITLE
Possible NPE with context going null

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -3286,7 +3286,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
          * having a sharing in progress UI if you wish to prevent user activity in the window between selecting a channel
          * and sharing complete.</p>
          *
-         * @param channelName Name of the selected application to share the link.
+         * @param channelName Name of the selected application to share the link. An empty string is returned if unable to resolve selected client name.
          */
         void onChannelSelected(String channelName);
     }

--- a/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
+++ b/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
@@ -186,7 +186,11 @@ class ShareLinkManager {
                     adapter.notifyDataSetChanged();
                 } else {
                     if (callback_ != null) {
-                        callback_.onChannelSelected(((ResolveInfo) view.getTag()).loadLabel(context_.getPackageManager()).toString());
+                        String selectedChannelName = "";
+                        if (view.getTag() != null && context_ != null && ((ResolveInfo) view.getTag()).loadLabel(context_.getPackageManager()) != null) {
+                            selectedChannelName = ((ResolveInfo) view.getTag()).loadLabel(context_.getPackageManager()).toString();
+                        }
+                        callback_.onChannelSelected(selectedChannelName);
                     }
                     adapter.selectedPos = pos;
                     adapter.notifyDataSetChanged();


### PR DESCRIPTION
Adding a proactive null check for the share link item selected.

@aaustin @EvangelosG 