### PR TITLE
IAE on getting intent extra

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -1261,15 +1261,15 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             }
 
             //Check for any push identifier in case app is launched by a push notification
-            if (activity != null && activity.getIntent() != null && activity.getIntent().getExtras() != null) {
-                try {
+            try {
+                if (activity != null && activity.getIntent() != null && activity.getIntent().getExtras() != null) {
                     String pushIdentifier = activity.getIntent().getExtras().getString(Defines.Jsonkey.AndroidPushNotificationKey.getKey()); // This seems producing unmarshalling errors in some corner cases
                     if (pushIdentifier != null && pushIdentifier.length() > 0) {
                         prefHelper_.setPushIdentifier(pushIdentifier);
                         return false;
                     }
-                } catch (Exception ignore) {
                 }
+            } catch (Exception ignore) {
             }
 
             //Check for link click id or app link


### PR DESCRIPTION
This is really a corner case and not able to reproduce. The crash log
shows the `intent.getExtra` throws illegal argument exception. It seems
like some Android version or device has issue in unmarshaling some
extra values with intent. Adding a crash protection

@aaustin @Sarkar @EvangelosG 