### PR TITLE
Temporary solution for Transaction too large

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2652,7 +2652,8 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             Log.i("BranchSDK", "Branch Warning: Please make sure Activity names set for auto deep link are correct!");
         } catch (ClassNotFoundException e) {
             Log.i("BranchSDK", "Branch Warning: Please make sure Activity names set for auto deep link are correct! Error while looking for activity " + deepLinkActivity);
-        } catch (JSONException ignore) {
+        } catch (Exception ignore) {
+            // Can get TransactionTooLarge Exception here if the Application info exceeds 1mb binder data limit. Usually results with manifest merge from SDKs
         }
     }
 


### PR DESCRIPTION
Adding a temp fix for Transaction too large issue. This will result in
auto deep link failure on getting this exception.

This need to be replaced with a better fix but involves some serious
changes with the way auto-deep link is configured in manifest

@aaustin @EvangelosG