### PR TITLE
Support for forced session restart

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2262,7 +2262,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     }
 
     /*
-     * Check for forced session restart. The Branch session is restarted if the incoming intent has $branch_force_new_session set to true.
+     * Check for forced session restart. The Branch session is restarted if the incoming intent has branch_force_new_session set to true.
      * This is for supporting opening a deep link path while app is already running in the foreground. Such as clicking push notification while app in foreground.
      *
      */

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -1263,10 +1263,15 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             //Check for any push identifier in case app is launched by a push notification
             try {
                 if (activity != null && activity.getIntent() != null && activity.getIntent().getExtras() != null) {
-                    String pushIdentifier = activity.getIntent().getExtras().getString(Defines.Jsonkey.AndroidPushNotificationKey.getKey()); // This seems producing unmarshalling errors in some corner cases
-                    if (pushIdentifier != null && pushIdentifier.length() > 0) {
-                        prefHelper_.setPushIdentifier(pushIdentifier);
-                        return false;
+                    if (activity.getIntent().getExtras().getBoolean(Defines.Jsonkey.BranchLinkUsed.getKey()) == false) {
+                        String pushIdentifier = activity.getIntent().getExtras().getString(Defines.Jsonkey.AndroidPushNotificationKey.getKey()); // This seems producing unmarshalling errors in some corner cases
+                        if (pushIdentifier != null && pushIdentifier.length() > 0) {
+                            prefHelper_.setPushIdentifier(pushIdentifier);
+                            Intent thisIntent = activity.getIntent();
+                            thisIntent.putExtra(Defines.Jsonkey.BranchLinkUsed.getKey(), true);
+                            activity.setIntent(thisIntent);
+                            return false;
+                        }
                     }
                 }
             } catch (Exception ignore) {
@@ -1304,11 +1309,11 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                             // Intent will have App link in data and lead to issue of getting wrong parameters. (In case of link click id since we are  looking for actual link click on back end this case will never happen)
                             if ((activity.getIntent().getFlags() & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) == 0) {
                                 if ((scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))
-                                        && data.getHost() != null && data.getHost().length() > 0 && data.getQueryParameter(Defines.Jsonkey.AppLinkUsed.getKey()) == null) {
+                                        && data.getHost() != null && data.getHost().length() > 0 && data.getQueryParameter(Defines.Jsonkey.BranchLinkUsed.getKey()) == null) {
                                     prefHelper_.setAppLink(data.toString());
                                     String uriString = data.toString();
                                     uriString += uriString.contains("?") ? "&" : "?";
-                                    uriString += Defines.Jsonkey.AppLinkUsed.getKey() + "=true";
+                                    uriString += Defines.Jsonkey.BranchLinkUsed.getKey() + "=true";
                                     activity.getIntent().setData(Uri.parse(uriString));
                                     return false;
                                 }

--- a/Branch-SDK/src/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/io/branch/referral/Defines.java
@@ -69,7 +69,7 @@ public class Defines {
         AndroidAppLinkURL("android_app_link_url"),
         AndroidPushNotificationKey("branch"),
         AndroidPushIdentifier("push_identifier"),
-        ForceNewBranchSession("$branch_force_new_session"),
+        ForceNewBranchSession("branch_force_new_session"),
 
         CanonicalIdentifier("$canonical_identifier"),
         ContentTitle(Branch.OG_TITLE),

--- a/Branch-SDK/src/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/io/branch/referral/Defines.java
@@ -15,7 +15,7 @@ public class Defines {
         SessionID("session_id"),
         LinkClickID("link_click_id"),
         FaceBookAppLinkChecked("facebook_app_link_checked"),
-        AppLinkUsed("branch_used"),
+        BranchLinkUsed("branch_used"),
         ReferringBranchIdentity("referring_branch_identity"),
         BranchIdentity("branch_identity"),
         BranchKey("branch_key"),

--- a/Branch-SDK/src/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/io/branch/referral/Defines.java
@@ -69,6 +69,7 @@ public class Defines {
         AndroidAppLinkURL("android_app_link_url"),
         AndroidPushNotificationKey("branch"),
         AndroidPushIdentifier("push_identifier"),
+        ForceNewBranchSession("$branch_force_new_session"),
 
         CanonicalIdentifier("$canonical_identifier"),
         ContentTitle(Branch.OG_TITLE),

--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ You can deep link to content from push notifications just by adding a Branch lin
        PendingIntent resultPendingIntent =  PendingIntent.getActivity(this, 0, resultIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 ```
 
+If you would like to support push notification based routing while your app already in foreground, please add the following to your notification intent.
+
+```java
+       intent.putExtra("$branch_force_new_session",true);
+```
+
 ### Configure your AndroidManifest.xml
 
 Note: Provide internet permission. Branch SDK need internet access to talk to Branch APIs.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ You can deep link to content from push notifications just by adding a Branch lin
 If you would like to support push notification based routing while your app already in foreground, please add the following to your notification intent.
 
 ```java
-       intent.putExtra("$branch_force_new_session",true);
+       intent.putExtra("branch_force_new_session",true);
 ```
 
 ### Configure your AndroidManifest.xml


### PR DESCRIPTION
Implementation  for forced session restart. The Branch session is
restarted if the incoming intent has $branch_force_new_session set to
true.
This is for supporting opening a deep link path while app is
already running in the foreground. Such as clicking push notification
while app in foreground.

@aaustin @EvangelosG 