### PR TITLE
Fix: Deep link params are not supplied on cold start with poor internet connection

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2200,6 +2200,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                 }
             }
             if (activityCnt_ < 1) { // Check if this is the first Activity.If so start a session.
+                initState_ = SESSION_STATE.UNINITIALISED;
                 // Check if debug mode is set in manifest. If so enable debug.
                 if (BranchUtil.isTestModeEnabled(context_)) {
                     prefHelper_.setExternDebug();


### PR DESCRIPTION
If the app is put to background before   receiving the  init response
close is not called (Since init is not happened yet. ) When init
response received finally SDK mark session as valid.
Upon next link click start since SDK thinks session started it returned
empty param

It is only reproducible  on a slower network. need to put app into
background before init finished.

Here is  customer reported issue on this
https://github.com/BranchMetrics/android-branch-deep-linking/issues/319

@aaustin @EvangelosG 