### PR TITLE
Updating Error Message

### DIFF
--- a/Branch-SDK/src/io/branch/referral/BranchStrongMatchHelper.java
+++ b/Branch-SDK/src/io/branch/referral/BranchStrongMatchHelper.java
@@ -123,7 +123,7 @@ class BranchStrongMatchHelper {
                     }
                 } else {
                     updateStrongMatchCheckFinished(callback);
-                    Log.d("BranchSDK", "Cannot use cookie-based matching while setDebug is enabled");
+                    Log.d("BranchSDK", "Cannot use cookie-based matching while TestMode is enabled");
                 }
             } catch (Throwable ignore) {
                 updateStrongMatchCheckFinished(callback);


### PR DESCRIPTION
"Cannot use cookie-based matching while setDebug is enabled" -- Android uses TestMode, iOS uses SetDebug, this error message should report TestMode ...?