### PR TITLE
Default check Facebook App Link local to false

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -284,7 +284,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
 
     private static boolean disableDeviceIDFetch_;
 
-    private boolean enableFacebookAppLinkCheck_ = true;
+    private boolean enableFacebookAppLinkCheck_ = false;
 
     private static boolean isSimulatingInstalls_;
 


### PR DESCRIPTION
@EvangelosG For some reason, this was defaulted to true. Since there also appears to be a bug with Facebook's SDK, it's causing trouble for partners. Separately, I'll file a Facebook bug for the deferred deep link API.