### PR TITLE
cleaning up setdebug

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -433,7 +433,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     public static void disableTestMode() {
         BranchUtil.isCustomDebugEnabled_ = false;
     }
-    public static void setDebug() {
+    public void setDebug() {
         enableTestMode();
     }
 

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -422,13 +422,19 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
 
     /**
      * <p>
-     * Enables the test mode for the SDK. This will use the Branch Test Keys.
+     * Enables/Disables the test mode for the SDK. This will use the Branch Test Keys.
      * This will also enable debug logs.
      * Note: This is same as setting "io.branch.sdk.TestMode" to "True" in Manifest file
      * </p>
      */
-    public void setDebug() {
+    public static void enableTestMode() {
         BranchUtil.isCustomDebugEnabled_ = true;
+    }
+    public static void disableTestMode() {
+        BranchUtil.isCustomDebugEnabled_ = false;
+    }
+    public static void setDebug() {
+        enableTestMode();
     }
 
     /**


### PR DESCRIPTION
set debug should be static, also it really shouldn’t be called set
debug at this point if the manifest variable we use is test mode? i
added static enabletestmode/disabletestmode, and kept setdebug which
calls enabletestmode. or i can go the other direction and choose to use
the name set debug to mirror iOS.