### PR TITLE
Func to init Branch properly programmatically

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -601,6 +601,38 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     }
 
     /**
+     * <p>Singleton method to return the pre-initialised, or newly initialise and return, a singleton
+     * object of the type {@link Branch}.</p>
+     *
+     * <p>Use this whenever you need to call a method directly on the {@link Branch} object.</p>
+     *
+     * @param context A {@link Context} from which this call was made.
+     * @param branchKey A {@link String} value used to initialize Branch.
+     * @return An initialised {@link Branch} object, either fetched from a pre-initialised
+     * instance within the singleton class, or a newly instantiated object where
+     * one was not already requested during the current app lifecycle.
+     */
+    @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+    public static Branch getAutoInstance(@NonNull Context context, String branchKey) {
+        isAutoSessionMode_ = true;
+        customReferrableSettings_ = CUSTOM_REFERRABLE_SETTINGS.USE_DEFAULT;
+        boolean isLive = !BranchUtil.isTestModeEnabled(context);
+        getBranchInstance(context, isLive);
+
+        if (branchKey.startsWith("key_")) {
+            boolean isNewBranchKeySet = branchReferral_.prefHelper_.setBranchKey(branchKey);
+            //on setting a new key clear link cache and pending requests
+            if (isNewBranchKeySet) {
+                branchReferral_.linkCache_.clear();
+                branchReferral_.requestQueue_.clear();
+            }
+        } else {
+            Log.e("BranchSDK", "Branch Key is invalid.Please check your BranchKey");
+        }
+        return branchReferral_;
+    }
+
+    /**
      * <p>If you configured the your Strings file according to the guide, you'll be able to use
      * the test version of your app by just calling this static method before calling initSession.</p>
      *

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -613,7 +613,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      * one was not already requested during the current app lifecycle.
      */
     @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
-    public static Branch getAutoInstance(@NonNull Context context, String branchKey) {
+    public static Branch getAutoInstance(@NonNull Context context, @NonNull String branchKey) {
         isAutoSessionMode_ = true;
         customReferrableSettings_ = CUSTOM_REFERRABLE_SETTINGS.USE_DEFAULT;
         boolean isLive = !BranchUtil.isTestModeEnabled(context);


### PR DESCRIPTION
@Sarkar func to init branch from app class as follows: Branch.getAutoInstance(this, "key");

No need for anything in the manifest regarding key(s).

Can you gimme a test?