### PR TITLE
Modified Listener for further channel customization

### DIFF
--- a/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
+++ b/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
@@ -915,9 +915,9 @@ public class BranchUniversalObject implements Parcelable {
         }
 
         @Override
-        public void onChannelSelected(String channelName) {
+        public void onChannelSelected(String channelName, Branch.ShareLinkBuilder builder) {
             if (originalCallback_ != null) {
-                originalCallback_.onChannelSelected(channelName);
+                originalCallback_.onChannelSelected(channelName, builder);
             }
         }
     }

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2421,7 +2421,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
          *
          * @param channelName Name of the selected application to share the link. An empty string is returned if unable to resolve selected client name.
          */
-        void onChannelSelected(String channelName);
+        void onChannelSelected(String channelName, Branch.ShareLinkBuilder builder);
     }
 
     /**

--- a/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
+++ b/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
@@ -190,7 +190,7 @@ class ShareLinkManager {
                         if (view.getTag() != null && context_ != null && ((ResolveInfo) view.getTag()).loadLabel(context_.getPackageManager()) != null) {
                             selectedChannelName = ((ResolveInfo) view.getTag()).loadLabel(context_.getPackageManager()).toString();
                         }
-                        callback_.onChannelSelected(selectedChannelName);
+                        callback_.onChannelSelected(selectedChannelName, builder_);
                     }
                     adapter.selectedPos = pos;
                     adapter.notifyDataSetChanged();


### PR DESCRIPTION
Example use case: Facebook/twitter/pinterest needs different aspect ratio images to show display correctly without cropping. With the new changes, we are able to set the image url of the short link builder class depending on which share channel the user selected