### PR TITLE
share sheet header item

### DIFF
--- a/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
+++ b/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
@@ -157,7 +157,7 @@ class ShareLinkManager {
         shareOptionListView.setBackgroundColor(Color.WHITE);
 
         if (builder_.getSharingTitleView() != null) {
-            shareOptionListView.addHeaderView(builder_.getSharingTitleView());
+            shareOptionListView.addHeaderView(builder_.getSharingTitleView(), null, false);
         } else if (!TextUtils.isEmpty(builder_.getSharingTitle())) {
             TextView textView = new TextView(context_);
             textView.setText(builder_.getSharingTitle());

--- a/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
+++ b/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
@@ -166,7 +166,7 @@ class ShareLinkManager {
             textView.setTextAppearance(context_, android.R.style.TextAppearance_Medium);
             textView.setTextColor(context_.getResources().getColor(android.R.color.darker_gray));
             textView.setPadding(leftMargin, padding, padding, padding);
-            shareOptionListView.addHeaderView(textView);
+            shareOptionListView.addHeaderView(textView, null, false);
         }
 
         shareOptionListView.setAdapter(adapter);


### PR DESCRIPTION
disable the sharesheet header item from being clickable, which was causing crashes. @sojanpr -- when creating a share sheet, if you include `.setSharingTitle("share using");` a clickable header item is added to the sharesheet that crashes when clicked. I changed the constructor being used to include isSelectable = false when adding the header item. Please let me know if this is the right course of action.