### PR TITLE
Collecting only needed info from intent extra

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -388,6 +388,11 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
 
     private static String cookieBasedMatchDomain_ = "app.link"; // Domain name used for cookie based matching.
 
+    /* List of keys whose values are collected from the Intent Extra.*/
+    private static final String[] EXTERNAL_INTENT_EXTRA_KEY_WHITE_LIST = new String[]{
+            "extra_launch_uri"   // Key for embedded uri in FB ads triggered intents
+    };
+
     /**
      * <p>The main constructor of the Branch class is private because the class uses the Singleton
      * pattern.</p>
@@ -1289,11 +1294,14 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
 
                             if (extraKeys.size() > 0) {
                                 JSONObject extrasJson = new JSONObject();
-                                for (String key : extraKeys) {
-                                    extrasJson.put(key, bundle.get(key));
-
+                                for (String key : EXTERNAL_INTENT_EXTRA_KEY_WHITE_LIST) {
+                                    if (extraKeys.contains(key)) {
+                                        extrasJson.put(key, bundle.get(key));
+                                    }
                                 }
-                                prefHelper_.setExternalIntentExtra(extrasJson.toString());
+                                if (extrasJson.length() > 0) {
+                                    prefHelper_.setExternalIntentExtra(extrasJson.toString());
+                                }
                             }
                         }
                     }

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -389,7 +389,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     private static String cookieBasedMatchDomain_ = "app.link"; // Domain name used for cookie based matching.
 
     /* List of keys whose values are collected from the Intent Extra.*/
-    private static final String[] EXTERNAL_INTENT_EXTRA_KEY_WHITE_LIST = new String[]{
+    private static final String[] EXTERNAL_INTENT_EXTRA_KEY_WHITE_LIST = new String[] {
             "extra_launch_uri"   // Key for embedded uri in FB ads triggered intents
     };
 


### PR DESCRIPTION
Currently Branch is looking only for `extra_launch_uri` in the intent
extra ignored ro support deplaning through FB Ads. So need to capture
that only

@aaustin @zeeshabnc @EvangelosG 