### PR TITLE
Fixing a possible crash

### DIFF
--- a/Branch-SDK/src/io/branch/indexing/ContentDiscoverer.java
+++ b/Branch-SDK/src/io/branch/indexing/ContentDiscoverer.java
@@ -190,11 +190,16 @@ public class ContentDiscoverer {
 
     private void discoverViewContents(ViewGroup viewGroup, JSONArray contentDataArray, JSONArray contentKeysArray, Resources res, boolean isClearText) {
         for (int i = 0; i < viewGroup.getChildCount(); i++) {
+            
             View childView = viewGroup.getChildAt(i);
-            if (childView.getVisibility() == View.VISIBLE) if (childView instanceof ViewGroup) {
+            if ((childView.getVisibility() == View.VISIBLE) && (childView instanceof ViewGroup)) {
                 discoverViewContents((ViewGroup) childView, contentDataArray, contentKeysArray, res, isClearText);
             } else {
-                String viewName = res.getResourceEntryName(childView.getId());
+                String viewName = String.valueOf(childView.getId());
+                try {
+                    viewName = res.getResourceEntryName(childView.getId());
+                } catch (Exception ignore) {
+                }
                 updateElementData(viewName, childView, isClearText, contentDataArray, contentKeysArray);
             }
         }


### PR DESCRIPTION
This fix is to wrap a possible crash when the resource cannot be
figured out with the ID. Also fixing an issue related to view iteration
logic.

@aaustin @EvangelosG @shekar9 