### PR TITLE
white list black list share sheet items

### DIFF
--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/CustomBranchApp.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/CustomBranchApp.java
@@ -3,7 +3,6 @@ package io.branch.branchandroiddemo;
 
 //import com.squareup.leakcanary.LeakCanary;
 
-import io.branch.referral.Branch;
 import io.branch.referral.BranchApp;
 
 public final class CustomBranchApp extends BranchApp {

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/CustomBranchApp.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/CustomBranchApp.java
@@ -3,12 +3,19 @@ package io.branch.branchandroiddemo;
 
 //import com.squareup.leakcanary.LeakCanary;
 
+import android.app.Application;
+
+import io.branch.referral.Branch;
 import io.branch.referral.BranchApp;
 
-public final class CustomBranchApp extends BranchApp {
+public final class CustomBranchApp extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+        //Branch.excludeFromShareSheet("com.Slack");
+        Branch.includeInShareSheet("com.twitter.android");
+        //Branch.includeInShareSheet("com.Slack");
+        Branch.getAutoInstance(this);
         // Uncomment to test memory leak
         // LeakCanary.install(this);
     }

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/CustomBranchApp.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/CustomBranchApp.java
@@ -3,19 +3,13 @@ package io.branch.branchandroiddemo;
 
 //import com.squareup.leakcanary.LeakCanary;
 
-import android.app.Application;
-
 import io.branch.referral.Branch;
 import io.branch.referral.BranchApp;
 
-public final class CustomBranchApp extends Application {
+public final class CustomBranchApp extends BranchApp {
     @Override
     public void onCreate() {
         super.onCreate();
-        //Branch.excludeFromShareSheet("com.Slack");
-        Branch.includeInShareSheet("com.twitter.android");
-        //Branch.includeInShareSheet("com.Slack");
-        Branch.getAutoInstance(this);
         // Uncomment to test memory leak
         // LeakCanary.install(this);
     }

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
@@ -257,8 +257,10 @@ public class MainActivity extends Activity {
                         .addPreferredSharingOption(SharingHelper.SHARE_WITH.MESSAGE)
                         .addPreferredSharingOption(SharingHelper.SHARE_WITH.TWITTER)
                         .setAsFullWidthStyle(true)
+                        .includeInShareSheet("com.Slack")
+                        .ex
                         .setSharingTitle("Share With");
-                // Define custom styel for the share sheet list view
+                // Define custom style for the share sheet list view
                 //.setStyleResourceID(R.style.Share_Sheet_Style);
 
                 branchUniversalObject.showShareSheet(MainActivity.this, linkProperties, shareSheetStyle, new Branch.BranchLinkShareListener() {

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
@@ -257,7 +257,6 @@ public class MainActivity extends Activity {
                         .addPreferredSharingOption(SharingHelper.SHARE_WITH.MESSAGE)
                         .addPreferredSharingOption(SharingHelper.SHARE_WITH.TWITTER)
                         .setAsFullWidthStyle(true)
-                        .includeInShareSheet("com.Slack")
                         .setSharingTitle("Share With");
                 // Define custom style for the share sheet list view
                 //.setStyleResourceID(R.style.Share_Sheet_Style);

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
@@ -258,7 +258,6 @@ public class MainActivity extends Activity {
                         .addPreferredSharingOption(SharingHelper.SHARE_WITH.TWITTER)
                         .setAsFullWidthStyle(true)
                         .includeInShareSheet("com.Slack")
-                        .ex
                         .setSharingTitle("Share With");
                 // Define custom style for the share sheet list view
                 //.setStyleResourceID(R.style.Share_Sheet_Style);

--- a/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
+++ b/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
@@ -591,14 +591,10 @@ public class BranchUniversalObject implements Parcelable {
             shareLinkBuilder.setSharingTitle(style.getSharingTitleView());
 
             if (style.getIncludedInShareSheet() != null && style.getIncludedInShareSheet().size() > 0) {
-                for (String s : style.getIncludedInShareSheet()) {
-                    shareLinkBuilder.includeInShareSheet(s);
-                }
+                shareLinkBuilder.includeInShareSheet(style.getIncludedInShareSheet());
             }
-            if (style.getExcludedFromShareSheet() != null && style.getIncludedInShareSheet().size() > 0) {
-                for (String s : style.getExcludedFromShareSheet()) {
-                    shareLinkBuilder.excludeFromShareSheet(s);
-                }
+            if (style.getExcludedFromShareSheet() != null && style.getExcludedFromShareSheet().size() > 0) {
+                shareLinkBuilder.excludeFromShareSheet(style.getExcludedFromShareSheet());
             }
 
             shareLinkBuilder.shareLink();

--- a/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
+++ b/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
@@ -589,6 +589,18 @@ public class BranchUniversalObject implements Parcelable {
             shareLinkBuilder.setAsFullWidthStyle(style.getIsFullWidthStyle());
             shareLinkBuilder.setSharingTitle(style.getSharingTitle());
             shareLinkBuilder.setSharingTitle(style.getSharingTitleView());
+
+            if (style.getIncludedInShareSheet() != null && style.getIncludedInShareSheet().size() > 0) {
+                for (String s : style.getIncludedInShareSheet()) {
+                    shareLinkBuilder.includeInShareSheet(s);
+                }
+            }
+            if (style.getExcludedFromShareSheet() != null && style.getIncludedInShareSheet().size() > 0) {
+                for (String s : style.getExcludedFromShareSheet()) {
+                    shareLinkBuilder.excludeFromShareSheet(s);
+                }
+            }
+
             shareLinkBuilder.shareLink();
         }
     }

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -29,6 +29,7 @@ import org.json.JSONObject;
 import java.lang.ref.WeakReference;
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
@@ -2862,8 +2863,8 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         private View sharingTitleView = null;
 
         BranchShortLinkBuilder shortLinkBuilder_;
-        private static List<String> includeInShareSheet = new ArrayList<>();
-        private static List<String> excludeFromShareSheet = new ArrayList<>();
+        private List<String> includeInShareSheet = new ArrayList<>();
+        private List<String> excludeFromShareSheet = new ArrayList<>();
 
         /**
          * <p>Creates options for sharing a link with other Applications. Creates a builder for sharing the link with
@@ -3192,12 +3193,32 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         }
 
         public ShareLinkBuilder excludeFromShareSheet(@NonNull String packageName) {
-            excludeFromShareSheet.add(packageName);
+            this.excludeFromShareSheet.add(packageName);
+            return this;
+        }
+
+        public ShareLinkBuilder excludeFromShareSheet(@NonNull String[] packageName) {
+            this.excludeFromShareSheet.addAll(Arrays.asList(packageName));
+            return this;
+        }
+
+        public ShareLinkBuilder excludeFromShareSheet(@NonNull List<String> packageNames) {
+            this.excludeFromShareSheet.addAll(packageNames);
             return this;
         }
 
         public ShareLinkBuilder includeInShareSheet(@NonNull String packageName) {
-            includeInShareSheet.add(packageName);
+            this.includeInShareSheet.add(packageName);
+            return this;
+        }
+
+        public ShareLinkBuilder includeInShareSheet(@NonNull String[] packageName) {
+            this.includeInShareSheet.addAll(Arrays.asList(packageName));
+            return this;
+        }
+
+        public ShareLinkBuilder includeInShareSheet(@NonNull List<String> packageNames) {
+            this.includeInShareSheet.addAll(packageNames);
             return this;
         }
         /**

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -394,9 +394,6 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             "extra_launch_uri"   // Key for embedded uri in FB ads triggered intents
     };
 
-    private static List<String> includeInShareSheet = new ArrayList<>();
-    private static List<String> excludeFromShareSheet = new ArrayList<>();
-
     /**
      * <p>The main constructor of the Branch class is private because the class uses the Singleton
      * pattern.</p>
@@ -446,20 +443,6 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     public void setDebug() {
         enableTestMode();
     }
-
-    public static void excludeFromShareSheet(@NonNull String packageName) {
-        excludeFromShareSheet.add(packageName);
-    }
-    public static void includeInShareSheet(@NonNull String packageName) {
-        includeInShareSheet.add(packageName);
-    }
-    public static List<String> getExcludedFromShareSheet() {
-        return excludeFromShareSheet;
-    }
-    public static List<String> getIncludedInShareSheet() {
-        return includeInShareSheet;
-    }
-
     /**
      * <p>Singleton method to return the pre-initialised object of the type {@link Branch}.
      * Make sure your app is instantiating {@link BranchApp} before calling this method
@@ -2879,6 +2862,8 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         private View sharingTitleView = null;
 
         BranchShortLinkBuilder shortLinkBuilder_;
+        private static List<String> includeInShareSheet = new ArrayList<>();
+        private static List<String> excludeFromShareSheet = new ArrayList<>();
 
         /**
          * <p>Creates options for sharing a link with other Applications. Creates a builder for sharing the link with
@@ -3206,7 +3191,15 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             return this;
         }
 
+        public ShareLinkBuilder excludeFromShareSheet(@NonNull String packageName) {
+            excludeFromShareSheet.add(packageName);
+            return this;
+        }
 
+        public ShareLinkBuilder includeInShareSheet(@NonNull String packageName) {
+            includeInShareSheet.add(packageName);
+            return this;
+        }
         /**
          * <p> Set the given style to the List View showing the share sheet</p>
          *
@@ -3234,6 +3227,14 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
 
         public ArrayList<SharingHelper.SHARE_WITH> getPreferredOptions() {
             return preferredOptions_;
+        }
+
+        public List<String> getExcludedFromShareSheet() {
+            return excludeFromShareSheet;
+        }
+
+        public List<String> getIncludedInShareSheet() {
+            return includeInShareSheet;
         }
 
         public Branch getBranch() {

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -3192,35 +3192,78 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             return this;
         }
 
+        /**
+         * Exclude items from the ShareSheet by package name String.
+         *
+         * @param packageName {@link String} package name to be excluded.
+         * @return this Builder object to allow for chaining of calls to set methods.
+         */
         public ShareLinkBuilder excludeFromShareSheet(@NonNull String packageName) {
             this.excludeFromShareSheet.add(packageName);
             return this;
         }
 
+        /**
+         * Exclude items from the ShareSheet by package name array.
+         *
+         * @param packageName {@link String[]} package name to be excluded.
+         * @return this Builder object to allow for chaining of calls to set methods.
+         */
         public ShareLinkBuilder excludeFromShareSheet(@NonNull String[] packageName) {
             this.excludeFromShareSheet.addAll(Arrays.asList(packageName));
             return this;
         }
 
+        /**
+         * Exclude items from the ShareSheet by package name List.
+         *
+         * @param packageNames {@link List<String>} package name to be excluded.
+         * @return this Builder object to allow for chaining of calls to set methods.
+         */
         public ShareLinkBuilder excludeFromShareSheet(@NonNull List<String> packageNames) {
             this.excludeFromShareSheet.addAll(packageNames);
             return this;
         }
 
+        /**
+         * Include items from the ShareSheet by package name String. If only "com.Slack"
+         * is included, then only preferred sharing options + Slack
+         * will be displayed, for example.
+         *
+         * @param packageName {@link String} package name to be included.
+         * @return this Builder object to allow for chaining of calls to set methods.
+         */
         public ShareLinkBuilder includeInShareSheet(@NonNull String packageName) {
             this.includeInShareSheet.add(packageName);
             return this;
         }
 
+        /**
+         * Include items from the ShareSheet by package name Array. If only "com.Slack"
+         * is included, then only preferred sharing options + Slack
+         * will be displayed, for example.
+         *
+         * @param packageName {@link String[]} package name to be included.
+         * @return this Builder object to allow for chaining of calls to set methods.
+         */
         public ShareLinkBuilder includeInShareSheet(@NonNull String[] packageName) {
             this.includeInShareSheet.addAll(Arrays.asList(packageName));
             return this;
         }
 
+        /**
+         * Include items from the ShareSheet by package name List. If only "com.Slack"
+         * is included, then only preferred sharing options + Slack
+         * will be displayed, for example.
+         *
+         * @param packageNames {@link List<String>} package name to be included.
+         * @return this Builder object to allow for chaining of calls to set methods.
+         */
         public ShareLinkBuilder includeInShareSheet(@NonNull List<String> packageNames) {
             this.includeInShareSheet.addAll(packageNames);
             return this;
         }
+
         /**
          * <p> Set the given style to the List View showing the share sheet</p>
          *
@@ -3250,11 +3293,11 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             return preferredOptions_;
         }
 
-        public List<String> getExcludedFromShareSheet() {
+        List<String> getExcludedFromShareSheet() {
             return excludeFromShareSheet;
         }
 
-        public List<String> getIncludedInShareSheet() {
+        List<String> getIncludedInShareSheet() {
             return includeInShareSheet;
         }
 

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -394,6 +394,9 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             "extra_launch_uri"   // Key for embedded uri in FB ads triggered intents
     };
 
+    private static List<String> includeInShareSheet = new ArrayList<>();
+    private static List<String> excludeFromShareSheet = new ArrayList<>();
+
     /**
      * <p>The main constructor of the Branch class is private because the class uses the Singleton
      * pattern.</p>
@@ -424,6 +427,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         }
         externalUriWhiteList_ = new ArrayList<>();
         skipExternalUriHosts_ = new ArrayList<>();
+
     }
 
     /**
@@ -441,6 +445,19 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     }
     public void setDebug() {
         enableTestMode();
+    }
+
+    public static void excludeFromShareSheet(@NonNull String packageName) {
+        excludeFromShareSheet.add(packageName);
+    }
+    public static void includeInShareSheet(@NonNull String packageName) {
+        includeInShareSheet.add(packageName);
+    }
+    public static List<String> getExcludedFromShareSheet() {
+        return excludeFromShareSheet;
+    }
+    public static List<String> getIncludedInShareSheet() {
+        return includeInShareSheet;
     }
 
     /**

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -1826,7 +1826,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     //-----------------Generate Short URL      -------------------------------------------//
 
     /**
-     * <p> Generates a shorl url fot the given {@link ServerRequestCreateUrl} object </p>
+     * <p> Generates a shorl url for the given {@link ServerRequestCreateUrl} object </p>
      *
      * @param req An instance  of {@link ServerRequestCreateUrl} with parameters create the short link.
      * @return A url created with the given request if the request is synchronous else null.

--- a/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
+++ b/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
@@ -158,10 +158,10 @@ class ShareLinkManager {
 
         //make sure our "show more" option includes preferred apps
         for (ResolveInfo r : matchingApps) {
-            for ( SharingHelper.SHARE_WITH shareWith : packagesFilterList)
-            if ( shareWith.toString().equalsIgnoreCase(r.activityInfo.packageName) ) {
-                cleanedMatchingAppsFinal.add(r);
-            }
+            for (SharingHelper.SHARE_WITH shareWith : packagesFilterList)
+                if (shareWith.toString().equalsIgnoreCase(r.activityInfo.packageName)) {
+                    cleanedMatchingAppsFinal.add(r);
+                }
         }
 
         cleanedMatchingAppsFinal.add(new CopyLinkItem());

--- a/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
+++ b/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
@@ -287,9 +287,14 @@ class ShareLinkManager {
                         }
                     }
                 }
-                isShareInProgress_ = false;
-                // Cancel the dialog and context is released on dialog cancel
-                cancelShareLinkDialog(false);
+                // Cancel the dialog and context is released on dialog cancel, but if
+                // failure is due to connection, continue with share.
+                if (error.getErrorCode() != BranchError.ERR_BRANCH_NO_CONNECTIVITY_STATUS) {
+                    cancelShareLinkDialog(false);
+                    isShareInProgress_ = false;
+                } else {
+                    shareWithClient(selectedResolveInfo, url, channelName);
+                }
             }
         }, true);
     }

--- a/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
+++ b/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
@@ -285,15 +285,14 @@ class ShareLinkManager {
                         } else {
                             Log.i("BranchSDK", "Unable to share link " + error.getMessage());
                         }
+
+                        if (error.getErrorCode() == BranchError.ERR_BRANCH_NO_CONNECTIVITY_STATUS) {
+                            shareWithClient(selectedResolveInfo, url, channelName);
+                        } else {
+                            cancelShareLinkDialog(false);
+                            isShareInProgress_ = false;
+                        }
                     }
-                }
-                // Cancel the dialog and context is released on dialog cancel, but if
-                // failure is due to connection, continue with share.
-                if (error.getErrorCode() != BranchError.ERR_BRANCH_NO_CONNECTIVITY_STATUS) {
-                    cancelShareLinkDialog(false);
-                    isShareInProgress_ = false;
-                } else {
-                    shareWithClient(selectedResolveInfo, url, channelName);
                 }
             }
         }, true);

--- a/Branch-SDK/src/io/branch/referral/util/ShareSheetStyle.java
+++ b/Branch-SDK/src/io/branch/referral/util/ShareSheetStyle.java
@@ -279,11 +279,11 @@ public class ShareSheetStyle {
         return this;
     }
 
-    List<String> getExcludedFromShareSheet() {
+    public List<String> getExcludedFromShareSheet() {
         return excludeFromShareSheet;
     }
 
-    List<String> getIncludedInShareSheet() {
+    public List<String> getIncludedInShareSheet() {
         return includeInShareSheet;
     }
 

--- a/Branch-SDK/src/io/branch/referral/util/ShareSheetStyle.java
+++ b/Branch-SDK/src/io/branch/referral/util/ShareSheetStyle.java
@@ -207,41 +207,83 @@ public class ShareSheetStyle {
         return this;
     }
 
+    /**
+     * Exclude items from the ShareSheet by package name String.
+     *
+     * @param packageName {@link String} package name to be excluded.
+     * @return this Builder object to allow for chaining of calls to set methods.
+     */
     public ShareSheetStyle excludeFromShareSheet(@NonNull String packageName) {
         this.excludeFromShareSheet.add(packageName);
         return this;
     }
 
+    /**
+     * Exclude items from the ShareSheet by package name array.
+     *
+     * @param packageName {@link String[]} package name to be excluded.
+     * @return this Builder object to allow for chaining of calls to set methods.
+     */
     public ShareSheetStyle excludeFromShareSheet(@NonNull String[] packageName) {
         excludeFromShareSheet.addAll(Arrays.asList(packageName));
         return this;
     }
 
+    /**
+     * Exclude items from the ShareSheet by package name List.
+     *
+     * @param packageNames {@link List<String>} package name to be excluded.
+     * @return this Builder object to allow for chaining of calls to set methods.
+     */
     public ShareSheetStyle excludeFromShareSheet(@NonNull List<String> packageNames) {
         this.excludeFromShareSheet.addAll(packageNames);
         return this;
     }
 
+    /**
+     * Include items from the ShareSheet by package name String. If only "com.Slack"
+     * is included, then only preferred sharing options + Slack
+     * will be displayed, for example.
+     *
+     * @param packageName {@link String} package name to be included.
+     * @return this Builder object to allow for chaining of calls to set methods.
+     */
     public ShareSheetStyle includeInShareSheet(@NonNull String packageName) {
         this.includeInShareSheet.add(packageName);
         return this;
     }
 
+    /**
+     * Include items from the ShareSheet by package name Array. If only "com.Slack"
+     * is included, then only preferred sharing options + Slack
+     * will be displayed, for example.
+     *
+     * @param packageName {@link String[]} package name to be included.
+     * @return this Builder object to allow for chaining of calls to set methods.
+     */
     public ShareSheetStyle includeInShareSheet(@NonNull String[] packageName) {
         includeInShareSheet.addAll(Arrays.asList(packageName));
         return this;
     }
 
+    /**
+     * Include items from the ShareSheet by package name List. If only "com.Slack"
+     * is included, then only preferred sharing options + Slack
+     * will be displayed, for example.
+     *
+     * @param packageNames {@link List<String>} package name to be included.
+     * @return this Builder object to allow for chaining of calls to set methods.
+     */
     public ShareSheetStyle includeInShareSheet(@NonNull List<String> packageNames) {
         this.includeInShareSheet.addAll(packageNames);
         return this;
     }
 
-    public List<String> getExcludedFromShareSheet() {
+    List<String> getExcludedFromShareSheet() {
         return excludeFromShareSheet;
     }
 
-    public List<String> getIncludedInShareSheet() {
+    List<String> getIncludedInShareSheet() {
         return includeInShareSheet;
     }
 

--- a/Branch-SDK/src/io/branch/referral/util/ShareSheetStyle.java
+++ b/Branch-SDK/src/io/branch/referral/util/ShareSheetStyle.java
@@ -11,6 +11,7 @@ import android.support.annotation.StyleRes;
 import android.view.View;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import io.branch.indexing.BranchUniversalObject;
@@ -212,9 +213,7 @@ public class ShareSheetStyle {
     }
 
     public ShareSheetStyle excludeFromShareSheet(@NonNull String[] packageName) {
-        for (String s : packageName) {
-            this.excludeFromShareSheet.add(s);
-        }
+        excludeFromShareSheet.addAll(Arrays.asList(packageName));
         return this;
     }
 
@@ -229,9 +228,7 @@ public class ShareSheetStyle {
     }
 
     public ShareSheetStyle includeInShareSheet(@NonNull String[] packageName) {
-        for (String s : packageName) {
-            this.includeInShareSheet.add(s);
-        }
+        includeInShareSheet.addAll(Arrays.asList(packageName));
         return this;
     }
 

--- a/Branch-SDK/src/io/branch/referral/util/ShareSheetStyle.java
+++ b/Branch-SDK/src/io/branch/referral/util/ShareSheetStyle.java
@@ -211,8 +211,32 @@ public class ShareSheetStyle {
         return this;
     }
 
+    public ShareSheetStyle excludeFromShareSheet(@NonNull String[] packageName) {
+        for (String s : packageName) {
+            this.excludeFromShareSheet.add(s);
+        }
+        return this;
+    }
+
+    public ShareSheetStyle excludeFromShareSheet(@NonNull List<String> packageNames) {
+        this.excludeFromShareSheet.addAll(packageNames);
+        return this;
+    }
+
     public ShareSheetStyle includeInShareSheet(@NonNull String packageName) {
         this.includeInShareSheet.add(packageName);
+        return this;
+    }
+
+    public ShareSheetStyle includeInShareSheet(@NonNull String[] packageName) {
+        for (String s : packageName) {
+            this.includeInShareSheet.add(s);
+        }
+        return this;
+    }
+
+    public ShareSheetStyle includeInShareSheet(@NonNull List<String> packageNames) {
+        this.includeInShareSheet.addAll(packageNames);
         return this;
     }
 

--- a/Branch-SDK/src/io/branch/referral/util/ShareSheetStyle.java
+++ b/Branch-SDK/src/io/branch/referral/util/ShareSheetStyle.java
@@ -11,6 +11,7 @@ import android.support.annotation.StyleRes;
 import android.view.View;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import io.branch.indexing.BranchUniversalObject;
 import io.branch.referral.Branch;
@@ -44,6 +45,9 @@ public class ShareSheetStyle {
 
     private String sharingTitle_ = null;
     private View sharingTitleView_ = null;
+
+    private List<String> includeInShareSheet = new ArrayList<>();
+    private List<String> excludeFromShareSheet = new ArrayList<>();
 
     public ShareSheetStyle(@NonNull Context context, @NonNull String messageTitle, @NonNull String messageBody) {
         context_ = context;
@@ -200,6 +204,24 @@ public class ShareSheetStyle {
     public ShareSheetStyle setSharingTitle(View titleView) {
         this.sharingTitleView_ = titleView;
         return this;
+    }
+
+    public ShareSheetStyle excludeFromShareSheet(@NonNull String packageName) {
+        this.excludeFromShareSheet.add(packageName);
+        return this;
+    }
+
+    public ShareSheetStyle includeInShareSheet(@NonNull String packageName) {
+        this.includeInShareSheet.add(packageName);
+        return this;
+    }
+
+    public List<String> getExcludedFromShareSheet() {
+        return excludeFromShareSheet;
+    }
+
+    public List<String> getIncludedInShareSheet() {
+        return includeInShareSheet;
     }
 
     public ArrayList<SharingHelper.SHARE_WITH> getPreferredOptions() {


### PR DESCRIPTION
[[call before getAutoInstance()]]
examples: 
Branch.includeInShareSheet("com.twitter.android");
Branch.excludeFromShareSheet("com.Slack");

first swing. @agrimn please test this out.