### PR TITLE
Adding support for Fragmented URLs

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -1405,8 +1405,19 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                                         && data.getHost() != null && data.getHost().length() > 0 && data.getQueryParameter(Defines.Jsonkey.BranchLinkUsed.getKey()) == null) {
                                     prefHelper_.setAppLink(data.toString());
                                     String uriString = data.toString();
+                                    // PRS: Support for URLs with fragments. Fragments need to be last part of the URL
+                                    String fragment = "";
+                                    String url_fragment_char = "#";
+                                    if (uriString.contains(url_fragment_char)) {
+                                        String[] splits = uriString.split(url_fragment_char);
+                                        uriString = splits[0];
+                                        fragment = splits[1];
+                                    }
                                     uriString += uriString.contains("?") ? "&" : "?";
                                     uriString += Defines.Jsonkey.BranchLinkUsed.getKey() + "=true";
+                                    if (!TextUtils.isEmpty(fragment)) {
+                                        uriString += url_fragment_char + fragment;
+                                    }
                                     activity.getIntent().setData(Uri.parse(uriString));
                                     return false;
                                 }


### PR DESCRIPTION
Support for URLs with fragments. Fragments need to be last part of the
URL. Adding Branch query params before the fragments

Test Link  :https://bnctestbed.test-app.link/Q1cJyzAiPC#.456

Steps: 
1) Open testbed app by clicking above app link (App should show auto deeplink page)

2)  Move back to MainActivity and background the app

3) Resume the app (App should not navigate to auto deep link activity)


@aaustin @EvangelosG @mparul 