### PR TITLE
Install Listner Fix

### DIFF
--- a/Branch-SDK/src/io/branch/referral/InstallListener.java
+++ b/Branch-SDK/src/io/branch/referral/InstallListener.java
@@ -29,19 +29,22 @@ public class InstallListener extends BroadcastReceiver {
 
 
     private static boolean isWaitingForReferrer;
+    // PRS : In case play store referrer get reported really fast as google fix bugs , this implementation will let the referrer parsed and stored
+    //       This will be reported when SDK ask for it
+    private static boolean unReportedReferrerAvailable;
 
-    public static void startInstallReferrerTime(final long delay) {
-        isWaitingForReferrer = true;
-        new Handler().postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                if (callback_ != null) {
-                    callback_.onInstallReferrerEventsFinished();
-                    callback_ = null;
-                    isWaitingForReferrer = false;
+    public static void captureInstallReferrer(final long maxWaitTime) {
+        if (unReportedReferrerAvailable) {
+            reportInstallReferrer();
+        } else {
+            isWaitingForReferrer = true;
+            new Handler().postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    reportInstallReferrer();
                 }
-            }
-        }, delay);
+            }, maxWaitTime);
+        }
     }
 
     @Override
@@ -61,28 +64,27 @@ public class InstallListener extends BroadcastReceiver {
                 }
 
                 PrefHelper prefHelper = PrefHelper.getInstance(context);
-                if (isWaitingForReferrer) {
-                    if (referrerMap.containsKey(Defines.Jsonkey.LinkClickID.getKey())) {
-                        installID_ = referrerMap.get(Defines.Jsonkey.LinkClickID.getKey());
-                        prefHelper.setLinkClickIdentifier(installID_);
 
-                    }
-                    // Check for full app conversion
-                    if (referrerMap.containsKey(Defines.Jsonkey.IsFullAppConv.getKey())
-                            && referrerMap.containsKey(Defines.Jsonkey.ReferringLink.getKey())) {
-                        prefHelper.setIsFullAppConversion(Boolean.parseBoolean(referrerMap.get(Defines.Jsonkey.IsFullAppConv.getKey())));
-                        prefHelper.setAppLink(referrerMap.get(Defines.Jsonkey.ReferringLink.getKey()));
-                    }
+                if (referrerMap.containsKey(Defines.Jsonkey.LinkClickID.getKey())) {
+                    installID_ = referrerMap.get(Defines.Jsonkey.LinkClickID.getKey());
+                    prefHelper.setLinkClickIdentifier(installID_);
+
+                }
+                // Check for full app conversion
+                if (referrerMap.containsKey(Defines.Jsonkey.IsFullAppConv.getKey())
+                        && referrerMap.containsKey(Defines.Jsonkey.ReferringLink.getKey())) {
+                    prefHelper.setIsFullAppConversion(Boolean.parseBoolean(referrerMap.get(Defines.Jsonkey.IsFullAppConv.getKey())));
+                    prefHelper.setAppLink(referrerMap.get(Defines.Jsonkey.ReferringLink.getKey()));
                 }
 
                 if (referrerMap.containsKey(Defines.Jsonkey.GoogleSearchInstallReferrer.getKey())) {
                     prefHelper.setGoogleSearchInstallIdentifier(referrerMap.get(Defines.Jsonkey.GoogleSearchInstallReferrer.getKey()));
                     prefHelper.setGooglePlayReferrer(rawReferrerString);
                 }
+                unReportedReferrerAvailable = true;
 
-                if (callback_ != null) {
-                    callback_.onInstallReferrerEventsFinished();
-                    callback_ = null;
+                if (isWaitingForReferrer) {
+                    reportInstallReferrer();
                 }
 
             } catch (UnsupportedEncodingException e) {
@@ -99,6 +101,14 @@ public class InstallListener extends BroadcastReceiver {
         return installID_;
     }
 
+    private static void reportInstallReferrer() {
+        if (callback_ != null) {
+            callback_.onInstallReferrerEventsFinished();
+            callback_ = null;
+            unReportedReferrerAvailable = false;
+        }
+    }
+
     public static void setListener(IInstallReferrerEvents installReferrerFetch) {
         callback_ = installReferrerFetch;
     }
@@ -106,5 +116,6 @@ public class InstallListener extends BroadcastReceiver {
     interface IInstallReferrerEvents {
         void onInstallReferrerEventsFinished();
     }
+
 
 }


### PR DESCRIPTION
There are below cases fixed 
1) Considering the case that url may contain query params with `=` and `&`
with it and may cause issue when parsing play store referrer.

On the receiving end the referrer is split based on ”&“ and each key
value  is detected by “=“ . The kay and value and again url decoded and
hence taking care of the double url encoding case

2)In case play store can deliver install listener faster or the install
listener get delayed, the current version misses the referrrer.  Added
changes to capture and save referrer and report it as soon as SDK ask
for it

@EvangelosG @aaustin @Sarkar 