### PR TITLE
Restrict Intent Read To Launcher

### DIFF
--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
@@ -2,6 +2,7 @@ package io.branch.branchandroiddemo;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -18,6 +19,7 @@ import io.branch.referral.Branch.BranchReferralInitListener;
 import io.branch.referral.Branch.BranchReferralStateChangedListener;
 import io.branch.referral.BranchError;
 import io.branch.referral.BranchViewHandler;
+import io.branch.referral.Defines;
 import io.branch.referral.SharingHelper;
 import io.branch.referral.util.CurrencyType;
 import io.branch.referral.util.LinkProperties;
@@ -214,6 +216,9 @@ public class MainActivity extends Activity {
             public void onClick(View v) {
                 Log.i("BranchTestBed", "Getting credit history...");
                 Intent i = new Intent(getApplicationContext(), CreditHistoryActivity.class);
+                // Test for preventing second intent reading
+                i.setData(Uri.parse("https://testintentread.app.link?error_if_assigned_to_android_app_link"));
+                i.putExtra(Defines.Jsonkey.ForceNewBranchSession.getKey(), false);
                 startActivity(i);
             }
         });

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2437,8 +2437,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             if (handleDelayedNewIntents_) {
                 intentState_ = INTENT_STATE.READY;
                 // Grab the intent only for first activity unless this activity is intent to  force new session
-                boolean grabIntentParams = (activity.getIntent() != null)
-                        && (activityCnt_ == 1 || activity.getIntent().getBooleanExtra(Defines.Jsonkey.ForceNewBranchSession.getKey(), false));
+                boolean grabIntentParams = activity.getIntent() != null && initState_ != SESSION_STATE.INITIALISED;
                 onIntentReady(activity, grabIntentParams);
             }
         }

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2283,9 +2283,10 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         registerInstallOrOpen(request, callback);
     }
 
-    private void onIntentReady(Activity activity) {
+    private void onIntentReady(Activity activity, boolean grabIntentParams) {
         requestQueue_.unlockProcessWait(ServerRequest.PROCESS_WAIT_LOCK.INTENT_PENDING_WAIT_LOCK);
-        if (activity.getIntent() != null) {
+        //if (activity.getIntent() != null) {
+        if (grabIntentParams) {
             Uri intentData = activity.getIntent().getData();
             readAndStripParam(intentData, activity);
             if (cookieBasedMatchDomain_ != null && prefHelper_.getBranchKey() != null && !prefHelper_.getBranchKey().equalsIgnoreCase(PrefHelper.NO_STRING_VALUE)) {
@@ -2435,7 +2436,10 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             currentActivityReference_ = new WeakReference<>(activity);
             if (handleDelayedNewIntents_) {
                 intentState_ = INTENT_STATE.READY;
-                onIntentReady(activity);
+                // Grab the intent only for first activity unless this activity is intent to  force new session
+                boolean grabIntentParams = (activity.getIntent() != null)
+                        && (activityCnt_ == 1 || activity.getIntent().getBooleanExtra(Defines.Jsonkey.ForceNewBranchSession.getKey(), false));
+                onIntentReady(activity, grabIntentParams);
             }
         }
 


### PR DESCRIPTION
Reading intent from first activity only unless there is a force new session requested

Test case
   Added test data to the intent which   launches the Credit History Activity with a testurl ( https://testintentread.app.link?error_if_assigned_to_android_app_link)

Here are the test steps
A)  Test redundant intent reading 
   1) Launch the test bedapp 
   2) Click `get credit history` button
   3) Press back and then background the app. 
   4) open app again by clicking app icon

  Expected result :  After step 4 the v1/open request shouldn’t  show 
`”android_app_link_url": "https:\/\/testintentread.app.link?error_if_assigned_to_android_app_link”`,

B)  Test Force New session
  1)  Enable Force new Session on launching credit history activity (Main
Activity.java #221)
   2) Repeat step and 1 and 2
  Expected Result : There should be a new v1/open after step 2 with 
` "android_app_link_url": "https:\/\/testintentread.app.link?error_if_assigned_to_android_app_link”,`

@aaustin @mparul @EvangelosG 