### PR TITLE
BadParcelableException fix

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -13,6 +13,7 @@ import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.BadParcelableException;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -2488,6 +2489,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      */
     private boolean checkIntentForSessionRestart(Intent intent) {
         boolean isRestartSessionRequested = false;
+        intent = BranchUtil.sanitizeIntent(intent);
         if (intent != null) {
             isRestartSessionRequested = intent.getBooleanExtra(Defines.Jsonkey.ForceNewBranchSession.getKey(), false);
             if (isRestartSessionRequested) {

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2486,9 +2486,11 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      * Check for forced session restart. The Branch session is restarted if the incoming intent has branch_force_new_session set to true.
      * This is for supporting opening a deep link path while app is already running in the foreground. Such as clicking push notification while app in foreground.
      *
-     * We are catching BadParcelableException because of this bug: https://chromium.googlesource.com/chromium/src/+/4bca3b37801c502a164536b804879c00aba7d304
-     * In some cases the parcel inside the intent we're parsing can be malformed, this protects us!
-     *
+     * We are catching BadParcelableException because of the issue reported here: https://github.com/BranchMetrics/android-branch-deep-linking/issues/464
+     * Which is also reported here, affecting Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=412527
+     * Explanation: In some cases the parcel inside the intent we're parsing from Chrome can be malformed, so we need some protection!
+     * The commit which resolved the issue in Chrome lives here: https://chromium.googlesource.com/chromium/src/+/4bca3b37801c502a164536b804879c00aba7d304
+     * We decided for now to protect this one line with a try/catch.
      */
     private boolean checkIntentForSessionRestart(Intent intent) {
         boolean isRestartSessionRequested = false;

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2489,9 +2489,12 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      */
     private boolean checkIntentForSessionRestart(Intent intent) {
         boolean isRestartSessionRequested = false;
-        intent = BranchUtil.sanitizeIntent(intent);
         if (intent != null) {
-            isRestartSessionRequested = intent.getBooleanExtra(Defines.Jsonkey.ForceNewBranchSession.getKey(), false);
+            try {
+                isRestartSessionRequested = intent.getBooleanExtra(Defines.Jsonkey.ForceNewBranchSession.getKey(), false);
+            } catch (BadParcelableException e) {
+
+            }
             if (isRestartSessionRequested) {
                 intent.putExtra(Defines.Jsonkey.ForceNewBranchSession.getKey(), false);
             }

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2486,6 +2486,9 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      * Check for forced session restart. The Branch session is restarted if the incoming intent has branch_force_new_session set to true.
      * This is for supporting opening a deep link path while app is already running in the foreground. Such as clicking push notification while app in foreground.
      *
+     * We are catching BadParcelableException because of this bug: https://chromium.googlesource.com/chromium/src/+/4bca3b37801c502a164536b804879c00aba7d304
+     * In some cases the parcel inside the intent we're parsing can be malformed, this protects us!
+     *
      */
     private boolean checkIntentForSessionRestart(Intent intent) {
         boolean isRestartSessionRequested = false;

--- a/Branch-SDK/src/io/branch/referral/BranchUtil.java
+++ b/Branch-SDK/src/io/branch/referral/BranchUtil.java
@@ -106,23 +106,12 @@ class BranchUtil {
         return filteredObj;
     }
 
-
     public static Drawable getDrawable(@NonNull Context context, @DrawableRes int drawableID) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             return context.getResources().getDrawable(drawableID, context.getTheme());
         } else {
             //noinspection deprecation
             return context.getResources().getDrawable(drawableID);
-        }
-    }
-
-    static Intent sanitizeIntent(final Intent incomingIntent) {
-        if (incomingIntent == null) return null;
-        try {
-            incomingIntent.getBooleanExtra(Defines.Jsonkey.ForceNewBranchSession.getKey(), false);
-            return incomingIntent;
-        } catch (BadParcelableException e) {
-            return incomingIntent.replaceExtras((Bundle) null);
         }
     }
 }

--- a/Branch-SDK/src/io/branch/referral/BranchUtil.java
+++ b/Branch-SDK/src/io/branch/referral/BranchUtil.java
@@ -1,11 +1,14 @@
 package io.branch.referral;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
+import android.os.BadParcelableException;
 import android.os.Build;
+import android.os.Bundle;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 
@@ -110,6 +113,16 @@ class BranchUtil {
         } else {
             //noinspection deprecation
             return context.getResources().getDrawable(drawableID);
+        }
+    }
+
+    static Intent sanitizeIntent(final Intent incomingIntent) {
+        if (incomingIntent == null) return null;
+        try {
+            incomingIntent.getBooleanExtra(Defines.Jsonkey.ForceNewBranchSession.getKey(), false);
+            return incomingIntent;
+        } catch (BadParcelableException e) {
+            return incomingIntent.replaceExtras((Bundle) null);
         }
     }
 }

--- a/Branch-SDK/src/io/branch/referral/BranchUtil.java
+++ b/Branch-SDK/src/io/branch/referral/BranchUtil.java
@@ -1,14 +1,11 @@
 package io.branch.referral;
 
 import android.content.Context;
-import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
-import android.os.BadParcelableException;
 import android.os.Build;
-import android.os.Bundle;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 


### PR DESCRIPTION
In response to issue: https://github.com/BranchMetrics/android-branch-deep-linking/issues/464

Added a try/catch when parsing the Chrome intent's parcel. 