### PR TITLE
Sharesheeticonsizefix

### DIFF
--- a/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
+++ b/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
@@ -652,6 +652,7 @@ public class BranchUniversalObject implements Parcelable {
             shareLinkBuilder.setAsFullWidthStyle(style.getIsFullWidthStyle());
             shareLinkBuilder.setSharingTitle(style.getSharingTitle());
             shareLinkBuilder.setSharingTitle(style.getSharingTitleView());
+            shareLinkBuilder.setIconSize(style.getIconSize());
             
             if (style.getIncludedInShareSheet() != null && style.getIncludedInShareSheet().size() > 0) {
                 shareLinkBuilder.includeInShareSheet(style.getIncludedInShareSheet());

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2974,7 +2974,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         private String sharingTitle = null;
         private View sharingTitleView = null;
 
-        private int iconSize_ = 0;
+        private int iconSize_ = 50;
 
         BranchShortLinkBuilder shortLinkBuilder_;
         private List<String> includeInShareSheet = new ArrayList<>();

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2974,6 +2974,8 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         private String sharingTitle = null;
         private View sharingTitleView = null;
 
+        private int iconSize_ = 0;
+
         BranchShortLinkBuilder shortLinkBuilder_;
         private List<String> includeInShareSheet = new ArrayList<>();
         private List<String> excludeFromShareSheet = new ArrayList<>();
@@ -3305,6 +3307,17 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         }
 
         /**
+         * Set icon size for the sharing dialog
+         *
+         * @param iconSize {@link int} for setting the share sheet icon size.
+         * @return this Builder object to allow for chaining of calls to set methods.
+         */
+        public ShareLinkBuilder setIconSize(int iconSize) {
+            this.iconSize_ = iconSize;
+            return this;
+        }
+
+        /**
          * Exclude items from the ShareSheet by package name String.
          *
          * @param packageName {@link String} package name to be excluded.
@@ -3480,6 +3493,8 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         public int getStyleResourceID() {
             return styleResourceID_;
         }
+
+        public int getIconSize() { return iconSize_; }
     }
 
     //------------------------ Content Indexing methods----------------------//

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2973,7 +2973,6 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         private int dividerHeight = -1;
         private String sharingTitle = null;
         private View sharingTitleView = null;
-
         private int iconSize_ = 50;
 
         BranchShortLinkBuilder shortLinkBuilder_;

--- a/Branch-SDK/src/io/branch/referral/BranchUtil.java
+++ b/Branch-SDK/src/io/branch/referral/BranchUtil.java
@@ -8,6 +8,7 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
+import android.util.DisplayMetrics;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -111,4 +112,10 @@ class BranchUtil {
             return context.getResources().getDrawable(drawableID);
         }
     }
+
+    public static int dpToPx(Context context, int dp) {
+        DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
+        return Math.round(dp * (displayMetrics.xdpi / DisplayMetrics.DENSITY_DEFAULT));
+    }
+
 }

--- a/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
+++ b/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
@@ -50,9 +50,8 @@ class ShareLinkManager {
     private boolean isShareInProgress_ = false;
     /* Styleable resource for share sheet.*/
     private int shareDialogThemeID_ = -1;
-
+    /* Size of app icons in share sheet */
     private int iconSize_ = 50;
-
     private Branch.ShareLinkBuilder builder_;
     final int padding = 5;
     final int leftMargin = 100;

--- a/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
+++ b/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
@@ -51,7 +51,7 @@ class ShareLinkManager {
     /* Styleable resource for share sheet.*/
     private int shareDialogThemeID_ = -1;
 
-    private int iconSize_ = 0;
+    private int iconSize_ = 50;
 
     private Branch.ShareLinkBuilder builder_;
     final int padding = 5;
@@ -400,6 +400,7 @@ class ShareLinkManager {
      */
     private class ShareItemView extends TextView {
         Context context_;
+        int iconSizeDP_;
 
         public ShareItemView(Context context) {
             super(context);
@@ -407,6 +408,7 @@ class ShareLinkManager {
             this.setPadding(leftMargin, padding, padding, padding);
             this.setGravity(Gravity.START | Gravity.CENTER_VERTICAL);
             this.setMinWidth(context_.getResources().getDisplayMetrics().widthPixels);
+            this.iconSizeDP_ = iconSize_ != 0 ? BranchUtil.dpToPx(context, iconSize_) : 0;
         }
 
         public void setLabel(String appName, Drawable appIcon, boolean isEnabled) {
@@ -416,8 +418,8 @@ class ShareLinkManager {
                 this.setTextAppearance(context_, android.R.style.TextAppearance_Large);
                 this.setCompoundDrawablesWithIntrinsicBounds(null, null, null, null);
             } else {
-                if (iconSize_ != 0) {
-                    appIcon.setBounds(0, 0, iconSize_, iconSize_);
+                if (iconSizeDP_ != 0) {
+                    appIcon.setBounds(0, 0, iconSizeDP_, iconSizeDP_);
                     this.setCompoundDrawables(appIcon, null, null, null);
                 } else {
                     this.setCompoundDrawablesWithIntrinsicBounds(appIcon, null, null, null);

--- a/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
+++ b/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
@@ -51,6 +51,8 @@ class ShareLinkManager {
     /* Styleable resource for share sheet.*/
     private int shareDialogThemeID_ = -1;
 
+    private int iconSize_ = 0;
+
     private Branch.ShareLinkBuilder builder_;
     final int padding = 5;
     final int leftMargin = 100;
@@ -73,7 +75,7 @@ class ShareLinkManager {
         shareDialogThemeID_ = builder.getStyleResourceID();
         includeInShareSheet = builder.getIncludedInShareSheet();
         excludeFromShareSheet = builder.getExcludedFromShareSheet();
-
+        iconSize_ = builder.getIconSize();
         try {
             createShareDialog(builder.getPreferredOptions());
         } catch (Exception e) {
@@ -414,8 +416,13 @@ class ShareLinkManager {
                 this.setTextAppearance(context_, android.R.style.TextAppearance_Large);
                 this.setCompoundDrawablesWithIntrinsicBounds(null, null, null, null);
             } else {
+                if (iconSize_ != 0) {
+                    appIcon.setBounds(0, 0, iconSize_, iconSize_);
+                    this.setCompoundDrawables(appIcon, null, null, null);
+                } else {
+                    this.setCompoundDrawablesWithIntrinsicBounds(appIcon, null, null, null);
+                }
                 this.setTextAppearance(context_, android.R.style.TextAppearance_Medium);
-                this.setCompoundDrawablesWithIntrinsicBounds(appIcon, null, null, null);
                 viewItemMinHeight_ = Math.max(viewItemMinHeight_, (appIcon.getIntrinsicHeight() + padding));
             }
             this.setMinHeight(viewItemMinHeight_);

--- a/Branch-SDK/src/io/branch/referral/util/ShareSheetStyle.java
+++ b/Branch-SDK/src/io/branch/referral/util/ShareSheetStyle.java
@@ -50,7 +50,7 @@ public class ShareSheetStyle {
     private List<String> includeInShareSheet = new ArrayList<>();
     private List<String> excludeFromShareSheet = new ArrayList<>();
 
-    private int iconSize_ = 0;
+    private int iconSize_ = 50;
 
     public ShareSheetStyle(@NonNull Context context, @NonNull String messageTitle, @NonNull String messageBody) {
         context_ = context;
@@ -282,9 +282,9 @@ public class ShareSheetStyle {
     }
 
     /**
-     * Set icon size for the sharing dialog
+     * Set icon size (converted to DP) for the sharing dialog
      *
-     * @param iconSize {@link int} for setting the share sheet icon size(s).
+     * @param iconSize {@link int} for setting the share sheet icon size.
      * @return this Builder object to allow for chaining of calls to set methods.
      */
     public ShareSheetStyle setIconSize(int iconSize) {

--- a/Branch-SDK/src/io/branch/referral/util/ShareSheetStyle.java
+++ b/Branch-SDK/src/io/branch/referral/util/ShareSheetStyle.java
@@ -50,6 +50,8 @@ public class ShareSheetStyle {
     private List<String> includeInShareSheet = new ArrayList<>();
     private List<String> excludeFromShareSheet = new ArrayList<>();
 
+    private int iconSize_ = 0;
+
     public ShareSheetStyle(@NonNull Context context, @NonNull String messageTitle, @NonNull String messageBody) {
         context_ = context;
         moreOptionIcon_ = null;
@@ -279,6 +281,17 @@ public class ShareSheetStyle {
         return this;
     }
 
+    /**
+     * Set icon size for the sharing dialog
+     *
+     * @param iconSize {@link int} for setting the share sheet icon size(s).
+     * @return this Builder object to allow for chaining of calls to set methods.
+     */
+    public ShareSheetStyle setIconSize(int iconSize) {
+        this.iconSize_ = iconSize;
+        return this;
+    }
+
     public List<String> getExcludedFromShareSheet() {
         return excludeFromShareSheet;
     }
@@ -351,4 +364,6 @@ public class ShareSheetStyle {
     public int getStyleResourceID() {
         return styleResourceID_;
     }
+
+    public int getIconSize() { return iconSize_; }
 }

--- a/Branch-SDK/src/io/branch/referral/util/ShareSheetStyle.java
+++ b/Branch-SDK/src/io/branch/referral/util/ShareSheetStyle.java
@@ -43,15 +43,14 @@ public class ShareSheetStyle {
     final Context context_;
     private boolean setFullWidthStyle_;
     private int dividerHeight_ = -1;
+    private int iconSize_ = 50;
 
     private String sharingTitle_ = null;
     private View sharingTitleView_ = null;
 
     private List<String> includeInShareSheet = new ArrayList<>();
     private List<String> excludeFromShareSheet = new ArrayList<>();
-
-    private int iconSize_ = 50;
-
+    
     public ShareSheetStyle(@NonNull Context context, @NonNull String messageTitle, @NonNull String messageBody) {
         context_ = context;
         moreOptionIcon_ = null;


### PR DESCRIPTION
by default resize share sheet icons to 50DP.

added setIconSize to ShareSheetStyle. Android 8 introduced new, larger system icons. This resize code will ensure consistency amongst the old and the new icons. Usage: sharesheetstyle.setIconSize(int size)


