### PR TITLE
Fix for referrer kv issue on Android 6.0

### DIFF
--- a/Branch-SDK/src/io/branch/referral/InstallListener.java
+++ b/Branch-SDK/src/io/branch/referral/InstallListener.java
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Handler;
+import android.text.TextUtils;
 import android.util.Log;
 
 import java.io.UnsupportedEncodingException;
@@ -22,17 +23,17 @@ import java.util.HashMap;
  * </p>
  */
 public class InstallListener extends BroadcastReceiver {
-
+    
     /* Link identifier on installing app from play store. */
     private static String installID_ = PrefHelper.NO_STRING_VALUE;
     private static IInstallReferrerEvents callback_ = null;
-
-
+    
+    
     private static boolean isWaitingForReferrer;
     // PRS : In case play store referrer get reported really fast as google fix bugs , this implementation will let the referrer parsed and stored
     //       This will be reported when SDK ask for it
     private static boolean unReportedReferrerAvailable;
-
+    
     public static void captureInstallReferrer(final long maxWaitTime) {
         if (unReportedReferrerAvailable) {
             reportInstallReferrer();
@@ -46,7 +47,7 @@ public class InstallListener extends BroadcastReceiver {
             }, maxWaitTime);
         }
     }
-
+    
     @Override
     public void onReceive(Context context, Intent intent) {
         String rawReferrerString = intent.getStringExtra("referrer");
@@ -55,20 +56,26 @@ public class InstallListener extends BroadcastReceiver {
                 rawReferrerString = URLDecoder.decode(rawReferrerString, "UTF-8");
                 HashMap<String, String> referrerMap = new HashMap<>();
                 String[] referralParams = rawReferrerString.split("&");
-
+                
                 for (String referrerParam : referralParams) {
-                    String[] keyValue = referrerParam.split("=");
-                    if (keyValue.length > 1) { // To make sure that there is one key value pair in referrer
-                        referrerMap.put(URLDecoder.decode(keyValue[0], "UTF-8"), URLDecoder.decode(keyValue[1], "UTF-8"));
+                    if (!TextUtils.isEmpty(referrerParam)) {
+                        String splitter = "=";
+                        if (!referrerParam.contains("=") && referrerParam.contains("-")) {
+                            splitter = "-";
+                        }
+                        String[] keyValue = referrerParam.split(splitter);
+                        if (keyValue.length > 1) { // To make sure that there is one key value pair in referrer
+                            referrerMap.put(URLDecoder.decode(keyValue[0], "UTF-8"), URLDecoder.decode(keyValue[1], "UTF-8"));
+                        }
                     }
                 }
-
+                
                 PrefHelper prefHelper = PrefHelper.getInstance(context);
-
+                
                 if (referrerMap.containsKey(Defines.Jsonkey.LinkClickID.getKey())) {
                     installID_ = referrerMap.get(Defines.Jsonkey.LinkClickID.getKey());
                     prefHelper.setLinkClickIdentifier(installID_);
-
+                    
                 }
                 // Check for full app conversion
                 if (referrerMap.containsKey(Defines.Jsonkey.IsFullAppConv.getKey())
@@ -76,31 +83,31 @@ public class InstallListener extends BroadcastReceiver {
                     prefHelper.setIsFullAppConversion(Boolean.parseBoolean(referrerMap.get(Defines.Jsonkey.IsFullAppConv.getKey())));
                     prefHelper.setAppLink(referrerMap.get(Defines.Jsonkey.ReferringLink.getKey()));
                 }
-
+                
                 if (referrerMap.containsKey(Defines.Jsonkey.GoogleSearchInstallReferrer.getKey())) {
                     prefHelper.setGoogleSearchInstallIdentifier(referrerMap.get(Defines.Jsonkey.GoogleSearchInstallReferrer.getKey()));
                     prefHelper.setGooglePlayReferrer(rawReferrerString);
                 }
                 unReportedReferrerAvailable = true;
-
+                
                 if (isWaitingForReferrer) {
                     reportInstallReferrer();
                 }
-
+                
             } catch (UnsupportedEncodingException e) {
                 e.printStackTrace();
             } catch (IllegalArgumentException e) {
                 e.printStackTrace();
                 Log.w("BranchSDK", "Illegal characters in url encoded string");
             }
-
+            
         }
     }
-
+    
     public static String getInstallationID() {
         return installID_;
     }
-
+    
     private static void reportInstallReferrer() {
         if (callback_ != null) {
             callback_.onInstallReferrerEventsFinished();
@@ -108,14 +115,14 @@ public class InstallListener extends BroadcastReceiver {
             unReportedReferrerAvailable = false;
         }
     }
-
+    
     public static void setListener(IInstallReferrerEvents installReferrerFetch) {
         callback_ = installReferrerFetch;
     }
-
+    
     interface IInstallReferrerEvents {
         void onInstallReferrerEventsFinished();
     }
-
-
+    
+    
 }


### PR DESCRIPTION
It is found on Android 6.0 that the playstore referrer is not passed
when the referred params have `key=value` format. So on Branch back end
use `key-value` format for referrer passed with Android 6.0

@ahmednawar @aaustin @EvangelosG 