### PR TITLE
Add retry for IOException on doRestfulPost

### DIFF
--- a/Branch-SDK/src/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
+++ b/Branch-SDK/src/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
@@ -177,8 +177,18 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
                 throw new BranchRemoteException(BranchError.ERR_BRANCH_REQ_TIMED_OUT);
             }
         } catch (IOException ex) {
-            PrefHelper.Debug(getClass().getSimpleName(), "Http connect exception: " + ex.getMessage());
-            throw new BranchRemoteException(BranchError.ERR_BRANCH_NO_CONNECTIVITY);
+            if(retryNumber < prefHelper.getRetryCount()){
+                try {
+                    Thread.sleep(prefHelper.getRetryInterval());
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                retryNumber++;
+                return doRestfulPost(url, payload, retryNumber);
+            } else {
+                PrefHelper.Debug(getClass().getSimpleName(), "Http connect exception: " + ex.getMessage());
+                throw new BranchRemoteException(BranchError.ERR_BRANCH_NO_CONNECTIVITY);
+            }
         } catch (Exception ex) {
             PrefHelper.Debug(getClass().getSimpleName(), "Exception: " + ex.getMessage());
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB) {


### PR DESCRIPTION
We having a lot of "Poor connectivity" errors from our users, we want to be able to retry the branch deep-link request to the server on those cases.
