### PR TITLE
[INTENG-3874] Add Snapchat to Sharesheet Enum

### DIFF
--- a/Branch-SDK/src/io/branch/referral/SharingHelper.java
+++ b/Branch-SDK/src/io/branch/referral/SharingHelper.java
@@ -22,6 +22,7 @@ public class SharingHelper {
         HANGOUT("com.google.android.talk"),
         INSTAGRAM("com.instagram.android"),
         WECHAT("jom.tencent.mm"),
+        SNAPCHAT("com.snapchat.android"),
         GMAIL("com.google.android.gm");
 
         private String name = "";


### PR DESCRIPTION
A partner requested we add Snapchat to the shareSheet. However, it is a known issue that app.links don't linkify in Snapchat chat. 

Adding this small change in case we do want to support it.

Testing:
- Snapchat shows up in shareSheet
- Link does not linkify