### PR TITLE
Skipping instant deep linking on forcing new session

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -1328,7 +1328,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     
     private boolean readAndStripParam(Uri data, Activity activity) {
         // Check for instant deep linking possibility first
-        if (activity != null && activity.getIntent() != null && initState_ == SESSION_STATE.UNINITIALISED) {
+        if (activity != null && activity.getIntent() != null && initState_ == SESSION_STATE.UNINITIALISED && !checkIntentForSessionRestart(activity.getIntent())) {
             Intent intent = activity.getIntent();
             // In case of a cold start by clicking app icon or bringing app to foreground Branch link click is always false.
             if (intent.getData() == null || isIntentParamsAlreadyConsumed(activity)) {


### PR DESCRIPTION
Skipping instant deep linking on forcing new session.
Force new session carries the Branch link in the intent. In this case SDK need to talk to the Branch server to retrieve the referring params

@EvangelosG @ahmednawar @aaustin 