### PR TITLE
Updating request metadata on sending result

### DIFF
--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
@@ -337,6 +337,8 @@ public class MainActivity extends Activity {
                 }
             }
         }, this.getIntent().getData(), this);
+        
+        branch.setRequestMetadata("test_request_metadata", "Test_request_metadata_val");
     }
 
     @Override

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
@@ -337,8 +337,6 @@ public class MainActivity extends Activity {
                 }
             }
         }, this.getIntent().getData(), this);
-        
-        branch.setRequestMetadata("test_request_metadata", "Test_request_metadata_val");
     }
 
     @Override

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2684,6 +2684,8 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         protected void onPreExecute() {
             super.onPreExecute();
             thisReq_.onPreExecute();
+            // Update request metadata
+            thisReq_.updateRequestMetadata();
         }
         
         @Override
@@ -2691,7 +2693,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             if (thisReq_ instanceof ServerRequestInitSession) {
                 ((ServerRequestInitSession) thisReq_).updateLinkReferrerParams();
             }
-            //Update queue wait time
+            // update queue wait time
             addExtraInstrumentationData(thisReq_.getRequestPath() + "-" + Defines.Jsonkey.Queue_Wait_Time.getKey(), String.valueOf(thisReq_.getQueueWaitTime()));
             
             //Google ADs ID  and LAT value are updated using reflection. These method need background thread

--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -165,27 +165,6 @@ public abstract class ServerRequest {
      *             as key-value pairs.
      */
     protected void setPost(JSONObject post) {
-        // Take event level metadata, merge with top level metadata
-        // event level metadata takes precedence
-        try {
-            JSONObject metadata = new JSONObject();
-            Iterator<String> i = prefHelper_.getRequestMetadata().keys();
-            while (i.hasNext()) {
-                String k = i.next();
-                metadata.put(k, prefHelper_.getRequestMetadata().get(k));
-            }
-            if (post.has(Defines.Jsonkey.Metadata.getKey())) {
-                Iterator<String> postIter = post.getJSONObject(Defines.Jsonkey.Metadata.getKey()).keys();
-                while (postIter.hasNext()) {
-                    String key = postIter.next();
-                    // override keys from above
-                    metadata.put(key, post.getJSONObject(Defines.Jsonkey.Metadata.getKey()).get(key));
-                }
-            }
-            post.put(Defines.Jsonkey.Metadata.getKey(), metadata);
-        } catch (JSONException e) {
-            Log.e("BranchSDK", "Could not merge metadata, ignoring user metadata.");
-        }
         params_ = post;
         DeviceInfo.getInstance(prefHelper_.getExternDebug(), systemObserver_, disableAndroidIDFetch_).updateRequestWithDeviceParams(params_);
     }
@@ -384,7 +363,34 @@ public abstract class ServerRequest {
             }
         }
     }
-
+    
+    /**
+     * Update the additional metadata provided using {@link Branch#setRequestMetadata(String, String)} to the requests.
+     */
+    void updateRequestMetadata() {
+        // Take event level metadata, merge with top level metadata
+        // event level metadata takes precedence
+        try {
+            JSONObject metadata = new JSONObject();
+            Iterator<String> i = prefHelper_.getRequestMetadata().keys();
+            while (i.hasNext()) {
+                String k = i.next();
+                metadata.put(k, prefHelper_.getRequestMetadata().get(k));
+            }
+            JSONObject originalMetadata = params_.optJSONObject(Defines.Jsonkey.Metadata.getKey());
+            if (originalMetadata != null) {
+                Iterator<String> postIter = originalMetadata.keys();
+                while (postIter.hasNext()) {
+                    String key = postIter.next();
+                    // override keys from above
+                    metadata.put(key, originalMetadata.get(key));
+                }
+            }
+            params_.put(Defines.Jsonkey.Metadata.getKey(), metadata);
+        } catch (JSONException e) {
+            Log.e("BranchSDK", "Could not merge metadata, ignoring user metadata.");
+        }
+    }
 
     /*
      * Checks if this Application has internet permissions.


### PR DESCRIPTION
Update the additional metadata provided using {@link Branch#setRequestMetadata(String, String)} to the requests just before executing the request. This will allow  to capture request metadata set from activity `onStart()` method.

(Since most of the third party sdks has suggesting initialization on onStart())

@aaustin @agrimn 

