### PR TITLE
Ensuring backward compatibility in case using a deprecated BUO method for latest SDK

### DIFF
--- a/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
+++ b/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
@@ -157,6 +157,13 @@ public class BranchUniversalObject implements Parcelable {
      * @deprecated please use #setContentMetadata instead
      */
     public BranchUniversalObject addContentMetadata(HashMap<String, String> metadata) {
+        if (metadata != null) {
+            Iterator<String> keys = metadata.keySet().iterator();
+            while (keys.hasNext()) {
+                String key = keys.next();
+                metadata_.addCustomMetadata(key, metadata.get(key));
+            }
+        }
         return this;
     }
     
@@ -164,6 +171,7 @@ public class BranchUniversalObject implements Parcelable {
      * @deprecated please use #setContentMetadata instead
      */
     public BranchUniversalObject addContentMetadata(String key, String value) {
+        metadata_.addCustomMetadata(key, value);
         return this;
     }
     
@@ -403,7 +411,7 @@ public class BranchUniversalObject implements Parcelable {
      * @deprecated Please use #getContentMetadata() instead.
      */
     public HashMap<String, String> getMetadata() {
-        return null;
+        return metadata_.getCustomMetadata();
     }
     
     /**


### PR DESCRIPTION
`BUO# addContentMetadata()` is deprecated and new integration should use `BUO#setContentMetadata()`.
This fix ensure backward compatibility in case the app is still using the deprecated  methods

@aaustin @EvangelosG @derrickstaten 