### PR TITLE
Honour Delayed Param Reading For IDL

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -1331,7 +1331,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     private boolean readAndStripParam(Uri data, Activity activity) {
         if (intentState_ == INTENT_STATE.READY) {
             // Check for instant deep linking possibility first
-            if (activity != null && activity.getIntent() != null && initState_ == SESSION_STATE.UNINITIALISED && !checkIntentForSessionRestart(activity.getIntent())) {
+            if (activity != null && activity.getIntent() != null && initState_ != SESSION_STATE.INITIALISED && !checkIntentForSessionRestart(activity.getIntent())) {
                 Intent intent = activity.getIntent();
                 // In case of a cold start by clicking app icon or bringing app to foreground Branch link click is always false.
                 if (intent.getData() == null || isIntentParamsAlreadyConsumed(activity)) {


### PR DESCRIPTION
Since `onNewIntent()` is available `onStart()` Branch SDK already delay
the param reading until the `onStart()` happens. Check for instant deep
link possibility should be also done once the new intent is available.

@EvangelosG @code-crusher @aaustin 