### PR TITLE
Fixing IDL launch issue from history

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -1339,7 +1339,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             if (activity != null && activity.getIntent() != null && initState_ != SESSION_STATE.INITIALISED && !checkIntentForSessionRestart(activity.getIntent())) {
                 Intent intent = activity.getIntent();
                 // In case of a cold start by clicking app icon or bringing app to foreground Branch link click is always false.
-                if (intent.getData() == null || isIntentParamsAlreadyConsumed(activity)) {
+                if (intent.getData() == null || (!isActivityCreatedAndLaunched && isIntentParamsAlreadyConsumed(activity))) {
                     // Considering the case of a deferred install. In this case the app behaves like a cold start but still Branch can do probabilistic match.
                     // So skipping instant deep link feature until first Branch open happens
                     if (!prefHelper_.getInstallParams().equals(PrefHelper.NO_STRING_VALUE)) {


### PR DESCRIPTION
When a single task activity is launched from history the intents are
provided on the `onNewIntent` call. Fixing an issue for activities in
Branch used state an d IDL

@mparul @code-crusher 