### PR TITLE
Fix Maintain DataType In Metadata

### DIFF
--- a/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
+++ b/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
@@ -739,7 +739,7 @@ public class BranchUniversalObject implements Parcelable {
             Iterator<String> keys = metadataJson.keys();
             while (keys.hasNext()) {
                 String key = keys.next();
-                shortLinkBuilder.addParameters(key, metadataJson.getString(key));
+                shortLinkBuilder.addParameters(key, metadataJson.get(key));
             }
         } catch (JSONException e) {
             e.printStackTrace();

--- a/Branch-SDK/src/io/branch/referral/BranchUrlBuilder.java
+++ b/Branch-SDK/src/io/branch/referral/BranchUrlBuilder.java
@@ -93,11 +93,11 @@ abstract class BranchUrlBuilder<T extends BranchUrlBuilder> {
      * <p>Adds the the given key value pair to the parameters associated with this link.</p>
      *
      * @param key   A {@link String} with value of key for the parameter
-     * @param value A {@link String} with value of value for the parameter
+     * @param value A {@link Object} with value of value for the parameter
      * @return This Builder object to allow for chaining of calls to set methods.
      */
     @SuppressWarnings("unchecked")
-    public T addParameters(String key, String value) {
+    public T addParameters(String key, Object value) {
         try {
             if (this.params_ == null) {
                 this.params_ = new JSONObject();
@@ -108,20 +108,7 @@ abstract class BranchUrlBuilder<T extends BranchUrlBuilder> {
         }
         return (T) this;
     }
-
-    @SuppressWarnings("unchecked")
-    public T addParameters(String key, JSONArray value) {
-        try {
-            if (this.params_ == null) {
-                this.params_ = new JSONObject();
-            }
-            this.params_.put(key, value);
-        } catch (JSONException ignore) {
-
-        }
-        return (T) this;
-    }
-
+    
     public T setDefaultToLongUrl(boolean defaultToLongUrl) {
         defaultToLongUrl_ = defaultToLongUrl;
         return (T) this;


### PR DESCRIPTION
ContentMetadata in BUO was  not maintaining the datatype when it is
converted to JSON format. This causes the arrays in content metadata
misplaced in BUO.

Backward compatibility : Both  Android and iOS reads the data in
primitive type or convert the stringified value to original type. So
this is fully backward compatible


@antonargunov @jdee @E-B-Smith @aaustin 