### PR TITLE
Support for link data or property update on post share sheet events

### DIFF
--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
@@ -286,7 +286,7 @@ public class MainActivity extends Activity {
                 //.setStyleResourceID(R.style.Share_Sheet_Style);
 
                 branchUniversalObject.showShareSheet(MainActivity.this, linkProperties, shareSheetStyle, new Branch.BranchLinkShareListener() {
-
+            
                             @Override
                             public void onShareLinkDialogLaunched() {
                             }
@@ -302,6 +302,17 @@ public class MainActivity extends Activity {
                             @Override
                             public void onChannelSelected(String channelName) {
                             }
+            
+                            /**
+                             * Use {@link io.branch.referral.Branch.ExtendedBranchLinkShareListener} if the params need to be modified according to the channel selected by the user.
+                             * This allows modification of content or link properties through callback {@link #onChannelSelected(String,BranchUniversalObject,LinkProperties)} }
+                             */
+//                            @Override
+//                            public boolean onChannelSelected(String channelName, BranchUniversalObject buo, LinkProperties linkProperties) {
+//                                linkProperties.setAlias("http://bnc.lt/alias_link");
+//                                buo.setTitle("Custom Title for selected channel : " + channelName);
+//                                return true;
+//                            }
 
                         },
                         new Branch.IChannelProperties() {

--- a/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
+++ b/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
@@ -650,8 +650,8 @@ public class BranchUniversalObject implements Parcelable {
                 Log.e("BranchSDK", "Sharing error. Branch instance is not created yet. Make sure you have initialised Branch.");
             }
         } else {
-            Branch.ShareLinkBuilder shareLinkBuilder = new Branch.ShareLinkBuilder(activity, getLinkBuilder(activity, linkProperties))
-                    .setCallback(new LinkShareListenerWrapper(callback))
+            Branch.ShareLinkBuilder shareLinkBuilder = new Branch.ShareLinkBuilder(activity, getLinkBuilder(activity, linkProperties));
+            shareLinkBuilder.setCallback(new LinkShareListenerWrapper(callback,shareLinkBuilder, linkProperties))
                     .setChannelProperties(channelProperties)
                     .setSubject(style.getMessageTitle())
                     .setMessage(style.getMessageBody());
@@ -689,6 +689,10 @@ public class BranchUniversalObject implements Parcelable {
     
     private BranchShortLinkBuilder getLinkBuilder(@NonNull Context context, @NonNull LinkProperties linkProperties) {
         BranchShortLinkBuilder shortLinkBuilder = new BranchShortLinkBuilder(context);
+        return getLinkBuilder(shortLinkBuilder, linkProperties);
+    }
+    
+    private BranchShortLinkBuilder getLinkBuilder(@NonNull BranchShortLinkBuilder shortLinkBuilder, @NonNull LinkProperties linkProperties) {
         if (linkProperties.getTags() != null) {
             shortLinkBuilder.addTags(linkProperties.getTags());
         }
@@ -710,7 +714,6 @@ public class BranchUniversalObject implements Parcelable {
         if (linkProperties.getMatchDuration() > 0) {
             shortLinkBuilder.setDuration(linkProperties.getMatchDuration());
         }
-        
         if (!TextUtils.isEmpty(title_)) {
             shortLinkBuilder.addParameters(Defines.Jsonkey.ContentTitle.getKey(), title_);
         }
@@ -938,9 +941,13 @@ public class BranchUniversalObject implements Parcelable {
      */
     private class LinkShareListenerWrapper implements Branch.BranchLinkShareListener {
         private final Branch.BranchLinkShareListener originalCallback_;
-        
-        LinkShareListenerWrapper(Branch.BranchLinkShareListener originalCallback) {
+        private final Branch.ShareLinkBuilder shareLinkBuilder_;
+        private final LinkProperties linkProperties_;
+    
+        LinkShareListenerWrapper(Branch.BranchLinkShareListener originalCallback, Branch.ShareLinkBuilder shareLinkBuilder, LinkProperties linkProperties) {
             originalCallback_ = originalCallback;
+            shareLinkBuilder_ = shareLinkBuilder;
+            linkProperties_ = linkProperties;
         }
         
         @Override
@@ -977,7 +984,13 @@ public class BranchUniversalObject implements Parcelable {
             if (originalCallback_ != null) {
                 originalCallback_.onChannelSelected(channelName);
             }
+            if (originalCallback_ instanceof Branch.ExtendedBranchLinkShareListener) {
+                if (((Branch.ExtendedBranchLinkShareListener) originalCallback_).onChannelSelected(channelName, BranchUniversalObject.this, linkProperties_)) {
+                    shareLinkBuilder_.setShortLinkBuilderInternal(getLinkBuilder(shareLinkBuilder_.getShortLinkBuilder(), linkProperties_));
+                }
+            }
         }
+        
     }
     
 }

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2639,6 +2639,26 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     }
     
     /**
+     * <p>An extended version of {@link BranchLinkShareListener} with callback that supports updating link data or properties after user select a channel to share
+     * This will provide the extended callback {@link #onChannelSelected(String, BranchUniversalObject, LinkProperties)} only when sharing a link using Branch Universal Object.</p>
+     */
+    public interface ExtendedBranchLinkShareListener extends BranchLinkShareListener {
+        /**
+         * <p>
+         * Called when user select a channel for sharing a deep link.
+         * This method allows modifying the link data and properties by providing the params  {@link BranchUniversalObject} and {@link LinkProperties}
+         * </p>
+         *
+         * @param channelName    The name of the channel user selected for sharing a link
+         * @param buo            {@link BranchUniversalObject} BUO used for sharing link for updating any params
+         * @param linkProperties {@link LinkProperties} associated with the sharing link for updating the properties
+         * @return Return {@code true} to create link with any updates added to the data ({@link BranchUniversalObject}) or to the properties ({@link LinkProperties}).
+         * Return {@code false} otherwise.
+         */
+        boolean onChannelSelected(String channelName, BranchUniversalObject buo, LinkProperties linkProperties);
+    }
+    
+    /**
      * <p>An interface class for customizing sharing properties with selected channel.</p>
      */
     public interface IChannelProperties {

--- a/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
+++ b/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
@@ -223,6 +223,7 @@ class ShareLinkManager {
                         if (view.getTag() != null && context_ != null && ((ResolveInfo) view.getTag()).loadLabel(context_.getPackageManager()) != null) {
                             selectedChannelName = ((ResolveInfo) view.getTag()).loadLabel(context_.getPackageManager()).toString();
                         }
+                        builder_.getShortLinkBuilder().setChannel(((ResolveInfo) view.getTag()).loadLabel(context_.getPackageManager()).toString());
                         callback_.onChannelSelected(selectedChannelName);
                     }
                     adapter.selectedPos = pos;
@@ -268,7 +269,6 @@ class ShareLinkManager {
         isShareInProgress_ = true;
         final String channelName = selectedResolveInfo.loadLabel(context_.getPackageManager()).toString();
         BranchShortLinkBuilder shortLinkBuilder = builder_.getShortLinkBuilder();
-        shortLinkBuilder.setChannel(channelName);
 
         shortLinkBuilder.generateShortUrlInternal(new Branch.BranchLinkCreateListener() {
             @Override

--- a/README.md
+++ b/README.md
@@ -696,7 +696,7 @@ To show the share sheet, call the following on your Branch Universal Object. The
 branchUniversalObject.showShareSheet(this, 
                                       linkProperties,
                                       shareSheetStyle,
-                                       new Branch.BranchLinkShareListener() {
+                                       new Branch.ExtendedBranchLinkShareListener() {
     @Override
     public void onShareLinkDialogLaunched() {
     }
@@ -708,6 +708,10 @@ branchUniversalObject.showShareSheet(this,
     }
     @Override
     public void onChannelSelected(String channelName) {
+    }
+    @Override
+    public boolean onChannelSelected(String channelName, BranchUniversalObject buo, LinkProperties linkProperties) {
+        return false;
     }
 });
 ```


### PR DESCRIPTION
Branch share sheet enhancement for controlling the link creation on Share sheet events. Allows apps to modify the link data or link properties after user has selected a channel for sharing the link with.

@aaustin @E-B-Smith 