### PR TITLE
Fixing issue :Re-open after offline install event fails

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -432,7 +432,6 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         linkCache_ = new HashMap<>();
         instrumentationExtraData_ = new ConcurrentHashMap<>();
         isGAParamsFetchInProgress_ = systemObserver_.prefetchGAdsParams(this);
-        InstallListener.setListener(this);
         // newIntent() delayed issue is only with Android M+ devices. So need to handle android M and above
         // PRS: Since this seem more reliable and not causing any integration issues adding this to all supported SDK versions
         if (android.os.Build.VERSION.SDK_INT >= 15) {
@@ -2315,7 +2314,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         }
         if (checkInstallReferrer_ && request instanceof ServerRequestRegisterInstall) {
             request.addProcessWaitLock(ServerRequest.PROCESS_WAIT_LOCK.INSTALL_REFERRER_FETCH_WAIT_LOCK);
-            InstallListener.captureInstallReferrer(playStoreReferrerFetchTime);
+            InstallListener.captureInstallReferrer(playStoreReferrerFetchTime, this);
         }
         
         registerInstallOrOpen(request, callback);

--- a/Branch-SDK/src/io/branch/referral/InstallListener.java
+++ b/Branch-SDK/src/io/branch/referral/InstallListener.java
@@ -34,7 +34,8 @@ public class InstallListener extends BroadcastReceiver {
     //       This will be reported when SDK ask for it
     private static boolean unReportedReferrerAvailable;
     
-    public static void captureInstallReferrer(final long maxWaitTime) {
+    public static void captureInstallReferrer(final long maxWaitTime, IInstallReferrerEvents installReferrerFetch) {
+        callback_ = installReferrerFetch;
         if (unReportedReferrerAvailable) {
             reportInstallReferrer();
         } else {
@@ -116,13 +117,8 @@ public class InstallListener extends BroadcastReceiver {
         }
     }
     
-    public static void setListener(IInstallReferrerEvents installReferrerFetch) {
-        callback_ = installReferrerFetch;
-    }
-    
     interface IInstallReferrerEvents {
         void onInstallReferrerEventsFinished();
     }
-    
     
 }


### PR DESCRIPTION
SDK was failing to do init session when there was a connectivity issue
while opening the app for first time.

This was caused by improperly nullifying the install listener callback
which will be null when app is opened from background causing app to
wait for install referrer finish forever.

@Sarkar @aaustin 