### PR TITLE
Disabling IDL by default

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -410,8 +410,8 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     boolean isInstantDeepLinkPossible = false;
     /* Flag to find if the activity is launched from stack (incase of  single top) or created fresh and launched */
     private boolean isActivityCreatedAndLaunched = false;
-    /* Flag to turn on or off instant deeplinking feature. IDL is enabled by default */
-    private static boolean disableInstantDeepLinking = false;
+    /* Flag to turn on or off instant deeplinking feature. IDL is disabled by default */
+    private static boolean disableInstantDeepLinking = true;
     
     /**
      * <p>The main constructor of the Branch class is private because the class uses the Singleton


### PR DESCRIPTION
detecting a regular open vs a deep linked open. We have added logic to
SDK to differentiate b/w a regular open and a deep linked open. We do
IDL in case of a regular open (Since there is link click data to pass).

Since few partners has issue with IDL in their app flow and disabling
IDL helped to fix the issue,  it is safe to make IDL opt -in until we
know what really causes the issue

@Sarkar 