### PR TITLE
Support Install Referrer lib

### DIFF
--- a/Branch-SDK/build.gradle
+++ b/Branch-SDK/build.gradle
@@ -8,10 +8,13 @@ dependencies {
     compile 'com.android.support:support-annotations:22.2.0'
     compile 'com.crashlytics.sdk.android:answers-shim:0.0.6'
 
-    // This is an optional dependency
-    //Please note that the Branch SDK does not require Firebase to operate. This dependency is listed here so there will not be build errors,
+    // --- optional dependencies -----
+    //Please note that the Branch SDK does not require any of the below optional dependencies to operate. This dependency is listed here so there will not be build errors,
     // but the library is *not* added to your app unless you do so yourself. Please check the code in gradle-mvn-push script to see how this works
+
     compile 'com.google.firebase:firebase-appindexing:10.0.1'
+    compile 'com.android.installreferrer:installreferrer:1.0'
+
 }
 
 android {

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2314,7 +2314,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         }
         if (checkInstallReferrer_ && request instanceof ServerRequestRegisterInstall) {
             request.addProcessWaitLock(ServerRequest.PROCESS_WAIT_LOCK.INSTALL_REFERRER_FETCH_WAIT_LOCK);
-            InstallListener.captureInstallReferrer(playStoreReferrerFetchTime, this);
+            InstallListener.captureInstallReferrer(context_, playStoreReferrerFetchTime, this);
         }
         
         registerInstallOrOpen(request, callback);

--- a/Branch-SDK/src/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/io/branch/referral/Defines.java
@@ -16,6 +16,8 @@ public class Defines {
         LinkClickID("link_click_id"),
         GoogleSearchInstallReferrer("google_search_install_referrer"),
         GooglePlayInstallReferrer("install_referrer_extras"),
+        ClickedReferrerTimeStamp("clicked_referrer_ts"),
+        InstallBeginTimeStamp("install_begin_ts"),
         FaceBookAppLinkChecked("facebook_app_link_checked"),
         BranchLinkUsed("branch_used"),
         ReferringBranchIdentity("referring_branch_identity"),
@@ -137,7 +139,7 @@ public class Defines {
         Environment("environment"),
         InstantApp("INSTANT_APP"),
         NativeApp("FULL_APP"),
-
+        
         TransactionID("transaction_id"),
         Currency("currency"),
         Revenue("revenue"),
@@ -147,7 +149,7 @@ public class Defines {
         Affiliation("affiliation"),
         Description("description"),
         SearchQuery("search_query"),
-
+        
         Name("name"),
         CustomData("custom_data"),
         EventData("event_data"),
@@ -175,7 +177,7 @@ public class Defines {
         ImageCaptions("$image_captions"),
         Condition("$condition"),
         CreationTimestamp("$creation_timestamp");
-
+        
         
         private String key = "";
         

--- a/Branch-SDK/src/io/branch/referral/InstallListener.java
+++ b/Branch-SDK/src/io/branch/referral/InstallListener.java
@@ -52,6 +52,13 @@ public class InstallListener extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         String rawReferrerString = intent.getStringExtra("referrer");
+        processRawReferrer(context, rawReferrerString);
+        if (isWaitingForReferrer) {
+            reportInstallReferrer();
+        }
+    }
+    
+    private void processRawReferrer(Context context, String rawReferrerString) {
         if (rawReferrerString != null) {
             try {
                 rawReferrerString = URLDecoder.decode(rawReferrerString, "UTF-8");
@@ -89,11 +96,6 @@ public class InstallListener extends BroadcastReceiver {
                     prefHelper.setGoogleSearchInstallIdentifier(referrerMap.get(Defines.Jsonkey.GoogleSearchInstallReferrer.getKey()));
                     prefHelper.setGooglePlayReferrer(rawReferrerString);
                 }
-                unReportedReferrerAvailable = true;
-                
-                if (isWaitingForReferrer) {
-                    reportInstallReferrer();
-                }
                 
             } catch (UnsupportedEncodingException e) {
                 e.printStackTrace();
@@ -101,7 +103,6 @@ public class InstallListener extends BroadcastReceiver {
                 e.printStackTrace();
                 Log.w("BranchSDK", "Illegal characters in url encoded string");
             }
-            
         }
     }
     
@@ -110,6 +111,7 @@ public class InstallListener extends BroadcastReceiver {
     }
     
     private static void reportInstallReferrer() {
+        unReportedReferrerAvailable = true;
         if (callback_ != null) {
             callback_.onInstallReferrerEventsFinished();
             callback_ = null;

--- a/Branch-SDK/src/io/branch/referral/InstallListener.java
+++ b/Branch-SDK/src/io/branch/referral/InstallListener.java
@@ -18,19 +18,18 @@ import java.util.HashMap;
 
 /**
  * <p> Class for listening installation referrer params. Install params are captured by either of the following methods
- *  1) Add the install referrer library to your application "com.android.installreferrer:installreferrer" (Recommended)
- *          dependencies {
- *               compile 'com.android.installreferrer:installreferrer:1.0'
- *          }
- *
- *  2) Add to a braodcast listener to manifest as follows to receive Install Referrer
- *  <receiver android:name="io.branch.referral.InstallListener" android:exported="true">
- *       <intent-filter>
- *           <action android:name="com.android.vending.INSTALL_REFERRER" />
- *       </intent-filter>
- *  </receiver> -->
+ * 1) Add the install referrer library to your application "com.android.installreferrer:installreferrer" (Recommended)
+ * dependencies {
+ * compile 'com.android.installreferrer:installreferrer:1.0'
+ * }
+ * <p>
+ * 2) Add to a braodcast listener to manifest as follows to receive Install Referrer
+ * <receiver android:name="io.branch.referral.InstallListener" android:exported="true">
+ * <intent-filter>
+ * <action android:name="com.android.vending.INSTALL_REFERRER" />
+ * </intent-filter>
+ * </receiver> -->
  * </p>
- *
  */
 public class InstallListener extends BroadcastReceiver {
     
@@ -85,8 +84,8 @@ public class InstallListener extends BroadcastReceiver {
     
     /**
      * <p>
-     *     Class for getting the referrer info using the install referrer client. This is need `installreferrer` lib added to the application.
-     *     This will be working only with compatible version of Play store app. In case of an error this fallback to the install-referrer broadcast
+     * Class for getting the referrer info using the install referrer client. This is need `installreferrer` lib added to the application.
+     * This will be working only with compatible version of Play store app. In case of an error this fallback to the install-referrer broadcast
      * </p>
      */
     private static class ReferrerClientWrapper {
@@ -155,7 +154,7 @@ public class InstallListener extends BroadcastReceiver {
             prefHelper.setLong(PrefHelper.KEY_REFERRER_CLICK_TS, referrerClickTS);
         }
         if (installClickTS > 0) {
-            prefHelper.setLong(PrefHelper.KEY_REFERRER_CLICK_TS, installClickTS);
+            prefHelper.setLong(PrefHelper.KEY_INSTALL_BEGIN_TS, installClickTS);
         }
         if (rawReferrerString != null) {
             try {
@@ -203,14 +202,6 @@ public class InstallListener extends BroadcastReceiver {
     
     public static String getInstallationID() {
         return installID_;
-    }
-    
-    public static long getReferrerClickTS(Context context) {
-        return PrefHelper.getInstance(context).getLong(PrefHelper.KEY_REFERRER_CLICK_TS);
-    }
-    
-    public static long getInstallBeginTS(Context context) {
-        return PrefHelper.getInstance(context).getLong(PrefHelper.KEY_INSTALL_BEGIN_TS);
     }
     
     private static void reportInstallReferrer() {

--- a/Branch-SDK/src/io/branch/referral/InstallListener.java
+++ b/Branch-SDK/src/io/branch/referral/InstallListener.java
@@ -4,23 +4,33 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Handler;
+import android.os.RemoteException;
 import android.text.TextUtils;
 import android.util.Log;
+
+import com.android.installreferrer.api.InstallReferrerClient;
+import com.android.installreferrer.api.InstallReferrerStateListener;
+import com.android.installreferrer.api.ReferrerDetails;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.HashMap;
 
 /**
- * <p> Class for listening installation referrer params. Add this class to your manifest in order to get a referrer info </p>
- * <p>
- * <p> Add to InstallListener to manifest as follows
- * <!--   <receiver android:name="io.branch.referral.InstallListener" android:exported="true">
- * <intent-filter>
- * <action android:name="com.android.vending.INSTALL_REFERRER" />
- * </intent-filter>
- * </receiver> -->
+ * <p> Class for listening installation referrer params. Install params are captured by either of the following methods
+ *  1) Add the install referrer library to your application "com.android.installreferrer:installreferrer" (Recommended)
+ *          dependencies {
+ *               compile 'com.android.installreferrer:installreferrer:1.0'
+ *          }
+ *
+ *  2) Add to a braodcast listener to manifest as follows to receive Install Referrer
+ *  <receiver android:name="io.branch.referral.InstallListener" android:exported="true">
+ *       <intent-filter>
+ *           <action android:name="com.android.vending.INSTALL_REFERRER" />
+ *       </intent-filter>
+ *  </receiver> -->
  * </p>
+ *
  */
 public class InstallListener extends BroadcastReceiver {
     
@@ -30,16 +40,20 @@ public class InstallListener extends BroadcastReceiver {
     
     
     private static boolean isWaitingForReferrer;
+    /* Specifies if the install referrer client is available */
+    private static boolean isReferrerClientAvailable;
     // PRS : In case play store referrer get reported really fast as google fix bugs , this implementation will let the referrer parsed and stored
     //       This will be reported when SDK ask for it
     private static boolean unReportedReferrerAvailable;
     
-    public static void captureInstallReferrer(final long maxWaitTime, IInstallReferrerEvents installReferrerFetch) {
+    public static void captureInstallReferrer(Context context, final long maxWaitTime, IInstallReferrerEvents installReferrerFetch) {
         callback_ = installReferrerFetch;
         if (unReportedReferrerAvailable) {
             reportInstallReferrer();
         } else {
             isWaitingForReferrer = true;
+            ReferrerClientWrapper referrerClientWrapper = new ReferrerClientWrapper(context);
+            isReferrerClientAvailable = referrerClientWrapper.getReferrerUsingReferrerClient();
             new Handler().postDelayed(new Runnable() {
                 @Override
                 public void run() {
@@ -52,13 +66,97 @@ public class InstallListener extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         String rawReferrerString = intent.getStringExtra("referrer");
-        processRawReferrer(context, rawReferrerString);
+        processReferrerInfo(context, rawReferrerString, 0, 0);
+        if (isWaitingForReferrer && !isReferrerClientAvailable) { // Still wait for referrer client to get the time stamps if it is active
+            reportInstallReferrer();
+        }
+    }
+    
+    private static void onReferrerClientFinished(Context context, String rawReferrerString, long clickTS, long InstallBeginTS) {
+        processReferrerInfo(context, rawReferrerString, clickTS, InstallBeginTS);
         if (isWaitingForReferrer) {
             reportInstallReferrer();
         }
     }
     
-    private void processRawReferrer(Context context, String rawReferrerString) {
+    private static void onReferrerClientError() {
+        isReferrerClientAvailable = false;
+    }
+    
+    /**
+     * <p>
+     *     Class for getting the referrer info using the install referrer client. This is need `installreferrer` lib added to the application.
+     *     This will be working only with compatible version of Play store app. In case of an error this fallback to the install-referrer broadcast
+     * </p>
+     */
+    private static class ReferrerClientWrapper {
+        private Object mReferrerClient; // Class may be unknown at the time on load if the `installreferrer` is missing
+        private Context context_;
+        
+        private ReferrerClientWrapper(Context context) {
+            this.context_ = context;
+        }
+        
+        private boolean getReferrerUsingReferrerClient() {
+            boolean isReferrerClientAvailable = false;
+            try {
+                InstallReferrerClient referrerClient = InstallReferrerClient.newBuilder(context_).build();
+                mReferrerClient = referrerClient;
+                referrerClient.startConnection(new InstallReferrerStateListener() {
+                    @Override
+                    public void onInstallReferrerSetupFinished(int responseCode) {
+                        switch (responseCode) {
+                            case InstallReferrerClient.InstallReferrerResponse.OK:
+                                try {
+                                    if (mReferrerClient != null) {
+                                        ReferrerDetails response = ((InstallReferrerClient) mReferrerClient).getInstallReferrer();
+                                        String rawReferrer = null;
+                                        long clickTimeStamp = 0L;
+                                        long installBeginTimeStamp = 0L;
+                                        if (response != null) {
+                                            rawReferrer = response.getInstallReferrer();
+                                            clickTimeStamp = response.getReferrerClickTimestampSeconds();
+                                            installBeginTimeStamp = response.getInstallBeginTimestampSeconds();
+                                        }
+                                        onReferrerClientFinished(context_, rawReferrer, clickTimeStamp, installBeginTimeStamp);
+                                    }
+                                } catch (RemoteException ex) {
+                                    PrefHelper.Debug("BranchSDK", ex.getMessage());
+                                    onReferrerClientError();
+                                }
+                                break;
+                            case InstallReferrerClient.InstallReferrerResponse.FEATURE_NOT_SUPPORTED:
+                                // API not available on the current Play Store app
+                                onReferrerClientError();
+                                break;
+                            case InstallReferrerClient.InstallReferrerResponse.SERVICE_UNAVAILABLE:
+                                // Connection could not be established
+                                onReferrerClientError();
+                                break;
+                        }
+                    }
+                    
+                    @Override
+                    public void onInstallReferrerServiceDisconnected() {
+                        onReferrerClientError();
+                    }
+                });
+                isReferrerClientAvailable = true;
+            } catch (Throwable ex) {
+                PrefHelper.Debug("BranchSDK", ex.getMessage());
+            }
+            return isReferrerClientAvailable;
+        }
+    }
+    
+    private static void processReferrerInfo(Context context, String rawReferrerString, long referrerClickTS, long installClickTS) {
+        PrefHelper prefHelper = PrefHelper.getInstance(context);
+        if (referrerClickTS > 0) {
+            prefHelper.setLong(PrefHelper.KEY_REFERRER_CLICK_TS, referrerClickTS);
+        }
+        if (installClickTS > 0) {
+            prefHelper.setLong(PrefHelper.KEY_REFERRER_CLICK_TS, installClickTS);
+        }
         if (rawReferrerString != null) {
             try {
                 rawReferrerString = URLDecoder.decode(rawReferrerString, "UTF-8");
@@ -77,9 +175,6 @@ public class InstallListener extends BroadcastReceiver {
                         }
                     }
                 }
-                
-                PrefHelper prefHelper = PrefHelper.getInstance(context);
-                
                 if (referrerMap.containsKey(Defines.Jsonkey.LinkClickID.getKey())) {
                     installID_ = referrerMap.get(Defines.Jsonkey.LinkClickID.getKey());
                     prefHelper.setLinkClickIdentifier(installID_);
@@ -110,12 +205,22 @@ public class InstallListener extends BroadcastReceiver {
         return installID_;
     }
     
+    public static long getReferrerClickTS(Context context) {
+        return PrefHelper.getInstance(context).getLong(PrefHelper.KEY_REFERRER_CLICK_TS);
+    }
+    
+    public static long getInstallBeginTS(Context context) {
+        return PrefHelper.getInstance(context).getLong(PrefHelper.KEY_INSTALL_BEGIN_TS);
+    }
+    
     private static void reportInstallReferrer() {
         unReportedReferrerAvailable = true;
         if (callback_ != null) {
             callback_.onInstallReferrerEventsFinished();
             callback_ = null;
             unReportedReferrerAvailable = false;
+            isWaitingForReferrer = false;
+            isReferrerClientAvailable = false;
         }
     }
     

--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -95,6 +95,9 @@ public class PrefHelper {
     private static final String KEY_INSTALL_REFERRER = "bnc_install_referrer";
     private static final String KEY_IS_FULL_APP_CONVERSION = "bnc_is_full_app_conversion";
     private static final String KEY_LIMIT_FACEBOOK_TRACKING = "bnc_limit_facebook_tracking";
+    
+    static final String KEY_REFERRER_CLICK_TS = "bnc_referrer_click_ts";
+    static final String KEY_INSTALL_BEGIN_TS = "bnc_install_begin_ts";
 
 
     private static String Branch_Key = null;

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
@@ -12,10 +12,10 @@ import org.json.JSONObject;
  * </p>
  */
 class ServerRequestRegisterInstall extends ServerRequestInitSession {
-
+    
     Branch.BranchReferralInitListener callback_;
     final SystemObserver systemObserver_;
-
+    
     /**
      * <p>Create an instance of {@link ServerRequestRegisterInstall} to notify Branch API on a new install.</p>
      *
@@ -27,7 +27,7 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
      */
     public ServerRequestRegisterInstall(Context context, Branch.BranchReferralInitListener callback,
                                         SystemObserver sysObserver, String installID) {
-
+        
         super(context, Defines.RequestPath.RegisterInstall.getPath());
         systemObserver_ = sysObserver;
         callback_ = callback;
@@ -36,54 +36,63 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
             if (!installID.equals(PrefHelper.NO_STRING_VALUE)) {
                 installPost.put(Defines.Jsonkey.LinkClickID.getKey(), installID);
             }
-
+            
             if (!sysObserver.getAppVersion().equals(SystemObserver.BLANK)) {
                 installPost.put(Defines.Jsonkey.AppVersion.getKey(), sysObserver.getAppVersion());
             }
-
+            
             // Read and update the URI scheme only if running in debug mode
             if (prefHelper_.getExternDebug()) {
                 String uriScheme = sysObserver.getURIScheme();
                 if (!uriScheme.equals(SystemObserver.BLANK))
                     installPost.put(Defines.Jsonkey.URIScheme.getKey(), uriScheme);
             }
-
+            
             installPost.put(Defines.Jsonkey.FaceBookAppLinkChecked.getKey(), prefHelper_.getIsAppLinkTriggeredInit());
             installPost.put(Defines.Jsonkey.IsReferrable.getKey(), prefHelper_.getIsReferrable());
             installPost.put(Defines.Jsonkey.Update.getKey(), sysObserver.getUpdateState());
             installPost.put(Defines.Jsonkey.Debug.getKey(), prefHelper_.getExternDebug());
+            
+            long clickedReferrerTS = InstallListener.getReferrerClickTS(context);
+            long installBeginTS = InstallListener.getInstallBeginTS(context);
+            if (clickedReferrerTS > 0) {
+                installPost.put(Defines.Jsonkey.ClickedReferrerTimeStamp.getKey(), clickedReferrerTS);
+            }
+            if (installBeginTS > 0) {
+                installPost.put(Defines.Jsonkey.InstallBeginTimeStamp.getKey(), installBeginTS);
+            }
             setPost(installPost);
-
+            
         } catch (JSONException ex) {
             ex.printStackTrace();
             constructError_ = true;
         }
-
-
+        
+        
     }
-
+    
     public ServerRequestRegisterInstall(String requestPath, JSONObject post, Context context) {
         super(requestPath, post, context);
         systemObserver_ = new SystemObserver(context);
     }
-
+    
     @Override
     public boolean hasCallBack() {
         return callback_ != null;
     }
-
+    
     @Override
     public void onRequestSucceeded(ServerResponse resp, Branch branch) {
         super.onRequestSucceeded(resp, branch);
         try {
             prefHelper_.setUserURL(resp.getObject().getString(Defines.Jsonkey.Link.getKey()));
-
+            
             if (resp.getObject().has(Defines.Jsonkey.Data.getKey())) {
                 JSONObject dataObj = new JSONObject(resp.getObject().getString(Defines.Jsonkey.Data.getKey()));
                 // If Clicked on a branch link
                 if (dataObj.has(Defines.Jsonkey.Clicked_Branch_Link.getKey())
                         && dataObj.getBoolean(Defines.Jsonkey.Clicked_Branch_Link.getKey())) {
-
+                    
                     // Check if there is any install params. Install param will be empty on until click a branch link
                     // or When a user logout
                     if (prefHelper_.getInstallParams().equals(PrefHelper.NO_STRING_VALUE)) {
@@ -95,13 +104,13 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
                     }
                 }
             }
-
+            
             if (resp.getObject().has(Defines.Jsonkey.LinkClickID.getKey())) {
                 prefHelper_.setLinkClickID(resp.getObject().getString(Defines.Jsonkey.LinkClickID.getKey()));
             } else {
                 prefHelper_.setLinkClickID(PrefHelper.NO_STRING_VALUE);
             }
-
+            
             if (resp.getObject().has(Defines.Jsonkey.Data.getKey())) {
                 String params = resp.getObject().getString(Defines.Jsonkey.Data.getKey());
                 prefHelper_.setSessionParams(params);
@@ -111,21 +120,21 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
             if (callback_ != null && !branch.isInitReportedThroughCallBack) {
                 callback_.onInitFinished(branch.getLatestReferringParams(), null);
             }
-
+            
             prefHelper_.setAppVersion(systemObserver_.getAppVersion());
-
+            
         } catch (Exception ex) {
             ex.printStackTrace();
         }
         onInitSessionCompleted(resp, branch);
     }
-
+    
     public void setInitFinishedCallback(Branch.BranchReferralInitListener callback) {
         if (callback != null) {  // Update callback if set with valid callback instance.
             callback_ = callback;
         }
     }
-
+    
     @Override
     public void handleFailure(int statusCode, String causeMsg) {
         if (callback_ != null) {
@@ -138,7 +147,7 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
             callback_.onInitFinished(obj, new BranchError("Trouble initializing Branch. " + causeMsg, statusCode));
         }
     }
-
+    
     @Override
     public boolean handleErrors(Context context) {
         if (!super.doesAppHasInternetPermission(context)) {
@@ -149,17 +158,17 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
         }
         return false;
     }
-
+    
     @Override
     public boolean isGetRequest() {
         return false;
     }
-
+    
     @Override
     public void clearCallbacks() {
         callback_ = null;
     }
-
+    
     @Override
     public String getRequestActionName() {
         return ACTION_INSTALL;

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
@@ -52,15 +52,6 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
             installPost.put(Defines.Jsonkey.IsReferrable.getKey(), prefHelper_.getIsReferrable());
             installPost.put(Defines.Jsonkey.Update.getKey(), sysObserver.getUpdateState());
             installPost.put(Defines.Jsonkey.Debug.getKey(), prefHelper_.getExternDebug());
-            
-            long clickedReferrerTS = InstallListener.getReferrerClickTS(context);
-            long installBeginTS = InstallListener.getInstallBeginTS(context);
-            if (clickedReferrerTS > 0) {
-                installPost.put(Defines.Jsonkey.ClickedReferrerTimeStamp.getKey(), clickedReferrerTS);
-            }
-            if (installBeginTS > 0) {
-                installPost.put(Defines.Jsonkey.InstallBeginTimeStamp.getKey(), installBeginTS);
-            }
             setPost(installPost);
             
         } catch (JSONException ex) {
@@ -74,6 +65,23 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
     public ServerRequestRegisterInstall(String requestPath, JSONObject post, Context context) {
         super(requestPath, post, context);
         systemObserver_ = new SystemObserver(context);
+    }
+    
+    @Override
+    public void onPreExecute() {
+        super.onPreExecute();
+        long clickedReferrerTS = prefHelper_.getLong(PrefHelper.KEY_REFERRER_CLICK_TS);
+        long installBeginTS = prefHelper_.getLong(PrefHelper.KEY_INSTALL_BEGIN_TS);
+        try {
+            if (clickedReferrerTS > 0) {
+                getPost().put(Defines.Jsonkey.ClickedReferrerTimeStamp.getKey(), clickedReferrerTS);
+            }
+            if (installBeginTS > 0) {
+                getPost().put(Defines.Jsonkey.InstallBeginTimeStamp.getKey(), installBeginTS);
+            }
+        } catch (JSONException ignore) {
+        
+        }
     }
     
     @Override

--- a/README.md
+++ b/README.md
@@ -848,6 +848,7 @@ This is often caused when you exclude the `answers-shim` module from Branch SDK 
 `-dontwarn com.crashlytics.android.answers.shim.**`
 
 ### Proguard warning or errors with `appindexing` module
-Branch SDK has optional dependency on Firebase app indexing classes to provide new Firebase content listing features. This may cause a proguard warning depending on your proguard settings.
+Branch SDK has optional dependencies on Firebase app indexing and Android install referrer classes to provide new Firebase content listing features and support new Android install referrer library. This may cause a proguard warning depending on your proguard settings.
 Please add the following to your proguard file to solve this issue
 `-dontwarn com.google.firebase.appindexing.**`
+`-dontwarn com.android.installreferrer.api.**`

--- a/build.gradle
+++ b/build.gradle
@@ -14,5 +14,8 @@ allprojects {
 
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com" // Google's Maven repository
+        }
     }
 }


### PR DESCRIPTION
Adding support for installreferrer library for getting  the referrer
info.
This is need `installreferrer` lib added to the application.
This will be working only with compatible version of Play store app. In
case of an error this fallback to the install-referrer broadcast.

Capture following  additional info on app install 
1) clicked_referrer_ts
2) install_begin_ts


@aaustin @Sarkar 