### PR TITLE
fix incorrect option highlighted in Share Dialog

### DIFF
--- a/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
+++ b/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
@@ -226,7 +226,7 @@ class ShareLinkManager {
                         builder_.getShortLinkBuilder().setChannel(((ResolveInfo) view.getTag()).loadLabel(context_.getPackageManager()).toString());
                         callback_.onChannelSelected(selectedChannelName);
                     }
-                    adapter.selectedPos = pos;
+                    adapter.selectedPos = pos - shareOptionListView.getHeaderViewsCount();
                     adapter.notifyDataSetChanged();
                     invokeSharingClient((ResolveInfo) view.getTag());
                     if (shareDlg_ != null) {


### PR DESCRIPTION
The problem is when using headers in a ListView they are also considered as items in the onItemClickListener, so you need to subtract the number of added headers from the current position to get REAL clicked position in ListView.