### PR TITLE
Adding support for Install metadata

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -880,8 +880,9 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      * A better place to call this  method is right after Branch#getAutoInstance()
      * </p>
      */
-    public void addInstallMetadata(@NonNull String key, @NonNull String value) {
+    public Branch addInstallMetadata(@NonNull String key, @NonNull String value) {
         prefHelper_.addInstallMetadata(key, value);
+        return this;
     }
     
     /**

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -872,6 +872,17 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     public void setRequestMetadata(@NonNull String key, @NonNull String value) {
         prefHelper_.setRequestMetadata(key, value);
     }
+
+    /**
+     * <p>
+     * This API allows to tag the install with custom attribute. Add any key-values that qualify or distinguish an install here.
+     * Please make sure this method is called before the Branch init, which is on the onStartMethod of first activity.
+     * A better place to call this  method is right after Branch#getAutoInstance()
+     * </p>
+     */
+    public void addInstallMetadata(@NonNull String key, @NonNull String value) {
+        prefHelper_.addInstallMetadata(key, value);
+    }
     
     /**
      * <p>Initialises a session with the Branch API, assigning a {@link BranchUniversalReferralInitListener}

--- a/Branch-SDK/src/io/branch/referral/Defines.java
+++ b/Branch-SDK/src/io/branch/referral/Defines.java
@@ -89,6 +89,7 @@ public class Defines {
         SDK("sdk"),
         SdkVersion("sdk_version"),
         UIMode("ui_mode"),
+        InstallMetadata("install_metadata"),
         
         Clicked_Branch_Link("+clicked_branch_link"),
         IsFirstSession("+is_first_session"),

--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -121,7 +121,12 @@ public class PrefHelper {
     /**
      * Arbitrary key values added to all requests.
      */
-    private JSONObject requestMetadata;
+    private final JSONObject requestMetadata;
+
+    /**
+     * Arbitrary key values added to Install requests.
+     */
+    private final JSONObject installMetadata;
     
     /**
      * Reference of application {@link Context}, normally the base context of the application.
@@ -132,13 +137,7 @@ public class PrefHelper {
      * Branch Content discovery data
      */
     private static JSONObject savedAnalyticsData_;
-    
-    /**
-     * <p>Empty, but required constructor for the {@link PrefHelper} {@link SharedPreferences}
-     * helper class.</p>
-     */
-    public PrefHelper() {
-    }
+
     
     /**
      * <p>Constructor with context passed from calling {@link Activity}.</p>
@@ -152,6 +151,7 @@ public class PrefHelper {
         this.prefsEditor_ = this.appSharedPrefs_.edit();
         this.context_ = context;
         this.requestMetadata = new JSONObject();
+        this.installMetadata = new JSONObject();
     }
     
     /**
@@ -1169,7 +1169,21 @@ public class PrefHelper {
     public JSONObject getRequestMetadata() {
         return this.requestMetadata;
     }
-    
+
+    void addInstallMetadata(String key, String value) {
+        if (key == null) {
+            return;
+        }
+        try {
+            installMetadata.putOpt(key, value);
+        } catch (JSONException ignore) {
+        }
+    }
+
+    public JSONObject getInstallMetadata() {
+        return installMetadata;
+    }
+
     /**
      * <p>Creates a <b>Debug</b> message in the debugger. If debugging is disabled, this will fail silently.</p>
      *

--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -451,6 +451,10 @@ public abstract class ServerRequest {
                     metadata.put(key, originalMetadata.get(key));
                 }
             }
+            // Install metadata need to be send only with Install request
+            if ((this instanceof ServerRequestRegisterInstall) && prefHelper_.getInstallMetadata().length() > 0) {
+                params_.putOpt(Defines.Jsonkey.InstallMetadata.getKey(), prefHelper_.getInstallMetadata());
+            }
             params_.put(Defines.Jsonkey.Metadata.getKey(), metadata);
         } catch (JSONException e) {
             Log.e("BranchSDK", "Could not merge metadata, ignoring user metadata.");


### PR DESCRIPTION
Adding API that  allows to tag the install with custom attribute. Add
any key-values that qualify or distinguish install .
Please make sure this method is called before the Branch init, which
is on the onStartMethod of first activity.
A better place to call this  method is right after
Branch#getAutoInstance()

@aaustin @Sarkar 