### PR TITLE
DEVEX-751: Always send standard events as standard even without object

### DIFF
--- a/Branch-SDK/src/io/branch/referral/util/BranchEvent.java
+++ b/Branch-SDK/src/io/branch/referral/util/BranchEvent.java
@@ -43,6 +43,13 @@ public class BranchEvent {
         standardProperties = new JSONObject();
         customProperties = new JSONObject();
         this.eventName = eventName;
+
+        for (BRANCH_STANDARD_EVENT event : BRANCH_STANDARD_EVENT.values()) {
+            if (eventName == event.getName()) {
+                isStandardEvent = true;
+            }
+        }
+
         this.isStandardEvent = isStandardEvent;
         buoList = new ArrayList<>();
     }


### PR DESCRIPTION
@E-B-Smith Android actually wasn't in parity with iOS here. With this change,

BranchEvent("PURCHASE")

will be treated the same as 

BranchEvent(BRANCH_STANDARD_EVENT.PURCHASE)