### PR TITLE
DEVEX-809 -- Change endpoint to api2.branch.io

### DIFF
--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -25,7 +25,12 @@ import java.util.Collections;
  * preference values.</p>
  */
 public class PrefHelper {
-    
+
+    /**
+     * The base URL to use for all calls to the Branch API.
+     */
+    private static final String BRANCH_BASE_URL = "https://api2.branch.io/";
+
     /**
      * {@link Boolean} value that enables/disables Branch developer external debug mode.
      */
@@ -177,7 +182,7 @@ public class PrefHelper {
      * API uses.
      */
     public String getAPIBaseUrl() {
-        return "https://api.branch.io/";
+        return BRANCH_BASE_URL;
     }
     
     /**


### PR DESCRIPTION
## Reference
DEVEX-809 -- Change endpoint to api2.branch.io

## Description
To support better wire encryption, we need to switch to an endpoint that does not allow degradation to older protocols.  We want to only support TLS 1.2 only as a minimum version.

## Testing Instructions
Sample app should continue to function.   To prove this, you should continue to see a `BranchSDK: returned {"sessionid":"xxxxxx"...` in the logs.

## Risk Assessment [`MEDIUM`]
This should theoretically be a low impact, as "of course" all devices will support the higher encryption protocol.   What makes this a higher risk is that there are a lot of older devices out there, and also devices in non-US  countries that may have limitations that we haven't tested against.

- [X] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
