### PR TITLE
[DEVEX-835] fix: unstable itemViewHeight

### DIFF
--- a/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
+++ b/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
@@ -47,6 +47,8 @@ class ShareLinkManager {
     Context context_;
     /* Default height for the list item.*/
     private static int viewItemMinHeight_ = 100;
+    /* Default icon height size multiplier*/
+    private static int ICON_SIZER = 3;
     /* Indicates whether a sharing is in progress*/
     private boolean isShareInProgress_ = false;
     /* Styleable resource for share sheet.*/
@@ -429,7 +431,7 @@ class ShareLinkManager {
                     this.setCompoundDrawablesWithIntrinsicBounds(appIcon, null, null, null);
                 }
                 this.setTextAppearance(context_, android.R.style.TextAppearance_Medium);
-                viewItemMinHeight_ = Math.max(viewItemMinHeight_, (appIcon.getIntrinsicHeight() + padding));
+                viewItemMinHeight_ = Math.max(viewItemMinHeight_, appIcon.getCurrent().getBounds().centerY()*ICON_SIZER + padding);
             }
             this.setMinHeight(viewItemMinHeight_);
             this.setTextColor(context_.getResources().getColor(android.R.color.black));


### PR DESCRIPTION
Changes:
Replaced the getIntrinsicHeight() with getCurrent().getBounds().centerY()*ICON_SIZER

This way there is a uniformity among all the icons. The default ICON_SIZER is 3 to compensate with the near-ish safe distance followed by Branch SDK as of now.

Yes, this works for non-Samsung devices also. 

Reviewers:
@Sarkar @aaaronlopez @apeterson-branch