### PR TITLE
[DEVEX - 888] feat: support for StrictPolicy#detectUntaggedSockets

### DIFF
--- a/Branch-SDK/src/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
+++ b/Branch-SDK/src/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
@@ -29,6 +29,8 @@ import io.branch.referral.PrefHelper;
  */
 public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
     private static final int DEFAULT_TIMEOUT = 3000;
+    private static final int THREAD_TAG_POST= 102;
+
     PrefHelper prefHelper;
 
     BranchRemoteInterfaceUrlConnection(Context context) {
@@ -123,6 +125,11 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
         } catch (JSONException ignore) {
         }
         try {
+            // set the setThreadStatsTag for POST if API 26+
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O){
+                TrafficStats.setThreadStatsTag(THREAD_TAG_POST);
+            }
+
             URL urlObject = new URL(url);
             connection = (HttpsURLConnection) urlObject.openConnection();
             connection.setConnectTimeout(timeout);


### PR DESCRIPTION
The TrafficStats.setThreadStatsTag() should be added just before using the OutputStreamWriter to abide the thread policy for Android O or above.

We don't need to use tagSocket() as we are not using any custom Socket, it's system default only.

Docs for ref: https://developer.android.com/reference/android/os/StrictMode.VmPolicy.Builder#detectUntaggedSockets()

Reviewers:
@Sarkar @aaaronlopez @apeterson-branch