### PR TITLE
INTENG-4460 -- Protection around getSystemService

### DIFF
--- a/Branch-SDK/src/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/io/branch/referral/SystemObserver.java
@@ -129,8 +129,9 @@ class SystemObserver {
         try {
             if (context_ != null) {
                 PackageInfo packageInfo = context_.getPackageManager().getPackageInfo(context_.getPackageName(), 0);
-                if (packageInfo.versionName != null)
+                if (packageInfo.versionName != null) {
                     return packageInfo.versionName;
+                }
             }
         } catch (NameNotFoundException ignored) {
         }

--- a/Branch-SDK/src/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/io/branch/referral/SystemObserver.java
@@ -14,7 +14,6 @@ import android.util.DisplayMetrics;
 import android.view.Display;
 import android.view.WindowManager;
 
-import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -45,7 +44,7 @@ class SystemObserver {
     int LATVal_ = 0;
 
 
-    private WeakReference<Context> contextReference_;
+    private Context context_;
 
     /**
      * <p>Indicates whether or not a real device ID is in use, or if a debug value is in use.</p>
@@ -59,7 +58,7 @@ class SystemObserver {
      * @param context Current application context
      */
     SystemObserver(Context context) {
-        contextReference_ = new WeakReference<>(context);
+        context_ = context;
         isRealHardwareId = true;
     }
 
@@ -76,11 +75,10 @@ class SystemObserver {
      * debug value in place of a real identifier.</p>
      */
     String getUniqueID(boolean debug) {
-        Context context = contextReference_.get();
-        if (context != null) {
+        if (context_ != null) {
             String androidID = null;
             if (!debug && !Branch.isSimulatingInstalls_) {
-                androidID = Secure.getString(context.getContentResolver(), Secure.ANDROID_ID);
+                androidID = Secure.getString(context_.getContentResolver(), Secure.ANDROID_ID);
             }
             if (androidID == null) {
                 androidID = UUID.randomUUID().toString();
@@ -110,10 +108,9 @@ class SystemObserver {
      */
     String getPackageName() {
         String packageName = "";
-        Context context = contextReference_.get();
-        if (context != null) {
+        if (context_ != null) {
             try {
-                PackageInfo info = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+                PackageInfo info = context_.getPackageManager().getPackageInfo(context_.getPackageName(), 0);
                 packageName = info.packageName;
             } catch (NameNotFoundException e) {
                 e.printStackTrace();
@@ -129,11 +126,9 @@ class SystemObserver {
      * currently integrated into.</p>
      */
     String getAppVersion() {
-        Context context = contextReference_.get();
-
         try {
-            if (context != null) {
-                PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+            if (context_ != null) {
+                PackageInfo packageInfo = context_.getPackageManager().getPackageInfo(context_.getPackageName(), 0);
                 if (packageInfo.versionName != null)
                     return packageInfo.versionName;
             }
@@ -241,10 +236,9 @@ class SystemObserver {
      * @see DisplayMetrics
      */
     DisplayMetrics getScreenDisplay() {
-        Context context = contextReference_.get();
         DisplayMetrics displayMetrics = new DisplayMetrics();
-        if (context != null) {
-            WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+        if (context_ != null) {
+            WindowManager windowManager = (WindowManager) context_.getSystemService(Context.WINDOW_SERVICE);
             if (windowManager != null) {
                 Display display = windowManager.getDefaultDisplay();
                 display.getMetrics(displayMetrics);
@@ -270,9 +264,8 @@ class SystemObserver {
      */
     @SuppressWarnings("MissingPermission")
     public boolean getWifiConnected() {
-        Context context = contextReference_.get();
-        if (context != null && PackageManager.PERMISSION_GRANTED == context.checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE)) {
-            ConnectivityManager connManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (context_ != null && PackageManager.PERMISSION_GRANTED == context_.checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE)) {
+            ConnectivityManager connManager = (ConnectivityManager) context_.getSystemService(Context.CONNECTIVITY_SERVICE);
             NetworkInfo wifiInfo = null;
             if (connManager != null) {
                 wifiInfo = connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
@@ -291,12 +284,11 @@ class SystemObserver {
      */
     private Object getAdInfoObject() {
         Object adInfoObj = null;
-        Context context = contextReference_.get();
-        if (context != null) {
+        if (context_ != null) {
             try {
                 Class<?> AdvertisingIdClientClass = Class.forName("com.google.android.gms.ads.identifier.AdvertisingIdClient");
                 Method getAdvertisingIdInfoMethod = AdvertisingIdClientClass.getMethod("getAdvertisingIdInfo", Context.class);
-                adInfoObj = getAdvertisingIdInfoMethod.invoke(null, context);
+                adInfoObj = getAdvertisingIdInfoMethod.invoke(null, context_);
             } catch (Throwable ignore) {
             }
         }
@@ -446,38 +438,41 @@ class SystemObserver {
      */
     String getUIMode() {
         String mode = "UI_MODE_TYPE_UNDEFINED";
-        Context context = contextReference_.get();
         UiModeManager modeManager = null;
 
-        if (context != null) {
-            modeManager = (UiModeManager)context.getSystemService(UI_MODE_SERVICE);
-        }
-
-        if (modeManager != null) {
-            switch (modeManager.getCurrentModeType()) {
-                case 1:
-                    mode = "UI_MODE_TYPE_NORMAL";
-                    break;
-                case 2:
-                    mode = "UI_MODE_TYPE_DESK";
-                    break;
-                case 3:
-                    mode = "UI_MODE_TYPE_CAR";
-                    break;
-                case 4:
-                    mode = "UI_MODE_TYPE_TELEVISION";
-                    break;
-                case 5:
-                    mode = "UI_MODE_TYPE_APPLIANCE";
-                    break;
-                case 6:
-                    mode = "UI_MODE_TYPE_WATCH";
-                    break;
-
-                case 0:
-                default:
-                    break;
+        try {
+            if (context_ != null) {
+                modeManager = (UiModeManager) context_.getSystemService(UI_MODE_SERVICE);
             }
+
+            if (modeManager != null) {
+                switch (modeManager.getCurrentModeType()) {
+                    case 1:
+                        mode = "UI_MODE_TYPE_NORMAL";
+                        break;
+                    case 2:
+                        mode = "UI_MODE_TYPE_DESK";
+                        break;
+                    case 3:
+                        mode = "UI_MODE_TYPE_CAR";
+                        break;
+                    case 4:
+                        mode = "UI_MODE_TYPE_TELEVISION";
+                        break;
+                    case 5:
+                        mode = "UI_MODE_TYPE_APPLIANCE";
+                        break;
+                    case 6:
+                        mode = "UI_MODE_TYPE_WATCH";
+                        break;
+
+                    case 0:
+                    default:
+                        break;
+                }
+            }
+        } catch (Exception e) {
+            // Have seen reports of "DeadSystemException" from UiModeManager.
         }
         return mode;
     }


### PR DESCRIPTION
## Reference
INTENG-4460 -- Exception in SystemObserver.getUIMode

## Description
Customer reports that an exception can be thrown when calling `getSystemService("uimode")`, if that returns null.

Note that I was not able to reproduce this issue in-house, however `lint` flagged that (and several other lines that were using `getSystemService()`) as potentially returning null.  I cleaned up the other calls in this class as well.  I also converted the Context to a WeakReference as well.

## Testing Instructions
* Sample app should continue to function.

## Risk Assessment [`MEDIUM`]
This is pretty core functionality.  It should be reviewed carefully.

- [X] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
