### PR TITLE
[INTENG-4373]better support for manual app opens with null intent 

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -294,7 +294,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     static boolean isForcedSession_ = false;
     
     private static boolean bypassCurrentActivityIntentState_ = false;
-    
+
     static boolean checkInstallReferrer_ = true;
     private static long playStoreReferrerFetchTime = 1500;
     public static final long NO_PLAY_STORE_REFERRER_WAIT = 0;
@@ -1470,8 +1470,8 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
             }
         }
         
-        // set the intentState_ as READY if bypassCurrentActivityIntentState_ is true and intent data is !null
-        if (bypassCurrentActivityIntentState_ && data != null) {
+        // set the intentState_ as READY if bypassCurrentActivityIntentState_ is true
+        if (bypassCurrentActivityIntentState_) {
             intentState_ = INTENT_STATE.READY;
         }
 


### PR DESCRIPTION
## Reference
INTENG-4373 -- Freecharge Android SDK integration(custom) 

## Description
As per our previous addition of Branch.enableBypassCurrentActivityIntentState(); to support bypassing of the Splash activity for the callbacks, we also need to add more support and faster response time for manual app opens where the intent is null. 

## Risk Assessment [`LOW`]
This change is only to support an already custom use-case which should not have an impact on the current Branch setup.

- [x] I, the PR creator, have tested — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [x] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [x] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [x] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [x] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)