### PR TITLE
SDK-87 -- Android InstallListener exception when not on UI thread

### DIFF
--- a/Branch-SDK/src/io/branch/referral/InstallListener.java
+++ b/Branch-SDK/src/io/branch/referral/InstallListener.java
@@ -3,7 +3,6 @@ package io.branch.referral;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Handler;
 import android.os.RemoteException;
 import android.text.TextUtils;
 import android.util.Log;
@@ -15,6 +14,8 @@ import com.android.installreferrer.api.ReferrerDetails;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.HashMap;
+import java.util.Timer;
+import java.util.TimerTask;
 
 /**
  * <p> Class for listening installation referrer params. Install params are captured by either of the following methods
@@ -53,7 +54,7 @@ public class InstallListener extends BroadcastReceiver {
             isWaitingForReferrer = true;
             ReferrerClientWrapper referrerClientWrapper = new ReferrerClientWrapper(context);
             isReferrerClientAvailable = referrerClientWrapper.getReferrerUsingReferrerClient();
-            new Handler().postDelayed(new Runnable() {
+            new Timer().schedule(new TimerTask() {
                 @Override
                 public void run() {
                     reportInstallReferrer();
@@ -131,6 +132,13 @@ public class InstallListener extends BroadcastReceiver {
                             case InstallReferrerClient.InstallReferrerResponse.SERVICE_UNAVAILABLE:
                                 // Connection could not be established
                                 onReferrerClientError();
+                                break;
+                            case InstallReferrerClient.InstallReferrerResponse.DEVELOPER_ERROR:
+                                // General errors caused by incorrect usage
+                                onReferrerClientError();
+                                break;
+                            case InstallReferrerClient.InstallReferrerResponse.SERVICE_DISCONNECTED:
+                                // Play Store service is not connected now - potentially transient state.
                                 break;
                         }
                     }


### PR DESCRIPTION
## Reference
SDK-87 -- Android InstallListener exception when not on UI thread

## Description
If an event is logged and the thread logging it is not the UI thread, there was an exception where the code is creating a new Handler() just to wait for 1500 milliseconds before reporting the install referrer.

This change uses a Timer instead.  Normally Timers should be avoided, but for this short of a duration it should not cause any issues.

### Note
Note that there were lint warnings as well, so I cleaned those up while in here.

## Testing Instructions
* Sample app should continue to function.
* Unit tests should all pass

I wrote a unit test (on a different branch) that proved the exception occurred before and is fixed afterwards.  Unfortunately that branch is now behind this one so unit tests were not checked in here.

## Risk Assessment [`LOW`]
Most of the changes here were around getting the unit tests in the other branch to prove the issue exists, and prove the issue was resolved.

- [X] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
