### PR TITLE
INTENG-4555 -- TLS1.2 issue with HttpsURLConnection on API Level 16~19 devices

### DIFF
--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -7,6 +7,7 @@ import android.content.SharedPreferences.Editor;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.Log;
@@ -29,7 +30,8 @@ public class PrefHelper {
     /**
      * The base URL to use for all calls to the Branch API.
      */
-    private static final String BRANCH_BASE_URL = "https://api2.branch.io/";
+    private static final String BRANCH_BASE_URL_V2 = "https://api2.branch.io/";
+    private static final String BRANCH_BASE_URL_V1 = "https://api.branch.io/";
 
     /**
      * {@link Boolean} value that enables/disables Branch developer external debug mode.
@@ -177,12 +179,18 @@ public class PrefHelper {
     
     /**
      * <p>Returns the base URL to use for all calls to the Branch API as a {@link String}.</p>
+     * NOTE: Below API v20, TLS 1.2 does not work reliably, so we will fall back in that case.
      *
      * @return A {@link String} variable containing the hard-coded base URL that the Branch
      * API uses.
      */
     public String getAPIBaseUrl() {
-        return BRANCH_BASE_URL;
+        if (Build.VERSION.SDK_INT >= 20) {
+            return BRANCH_BASE_URL_V2;
+        } else {
+            //
+            return BRANCH_BASE_URL_V1;
+        }
     }
     
     /**

--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -188,7 +188,6 @@ public class PrefHelper {
         if (Build.VERSION.SDK_INT >= 20) {
             return BRANCH_BASE_URL_V2;
         } else {
-            //
             return BRANCH_BASE_URL_V1;
         }
     }


### PR DESCRIPTION
## Reference
INTENG-4555 -- TLS1.2 issue with HttpsURLConnection on API Level 16~19 devices

## Description
There is a TLS1.2 issue with HttpsURLConnection on API Level 16~19 devices.

This affects all apps that have upgraded to a Branch SDK that uses the new `api2` endpoint, but are still running on older Android devices.

### NOTE 
NOTE that I spent quite a bit of time trying to get TLS 1.2 to work reliably on devices that don't support them natively, and at the point I was going down paths where I "Trust All Certificates" it became obvious that it would be better to just fall back to the original `api.branch.io` endpoint.

## Testing Instructions
* Sample app should continue to function on older devices (API 16-19).
* Sample app should continue to function on newer devices (API >= 20)

## Risk Assessment [`MEDIUM`]
While the actual change is pretty easy, we should probably make sure that any documentation that talks about TLS 1.2 should be reviewed.

- [X] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
