### PR TITLE
SDK-131 -- update gradle and prep for release

### DIFF
--- a/Branch-SDK-TestBed/AndroidManifest.xml
+++ b/Branch-SDK-TestBed/AndroidManifest.xml
@@ -5,8 +5,8 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="14"
-        android:targetSdkVersion="20" />
+        android:minSdkVersion="16"
+        android:targetSdkVersion="28" />
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/Branch-SDK-TestBed/androidTest/io/branch/branchandroiddemo/BUOTestRoutines.java
+++ b/Branch-SDK-TestBed/androidTest/io/branch/branchandroiddemo/BUOTestRoutines.java
@@ -1,4 +1,4 @@
-package io.branch.branchandroiddemo.test;
+package io.branch.branchandroiddemo;
 
 import android.content.Context;
 import android.os.Parcel;

--- a/Branch-SDK-TestBed/androidTest/io/branch/branchandroiddemo/TrackingControlTestRoutines.java
+++ b/Branch-SDK-TestBed/androidTest/io/branch/branchandroiddemo/TrackingControlTestRoutines.java
@@ -1,4 +1,4 @@
-package io.branch.branchandroiddemo.test;
+package io.branch.branchandroiddemo;
 
 import android.content.Context;
 import android.text.TextUtils;

--- a/Branch-SDK-TestBed/build.gradle
+++ b/Branch-SDK-TestBed/build.gradle
@@ -2,25 +2,31 @@ apply plugin: 'com.android.application'
 
 dependencies {
     implementation project(':Branch-SDK')
-    //debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.+'
     implementation ('com.google.android.gms:play-services-ads:16.0.0')
 
     /* Add chrome custom tabs for guaranteed matching */
     implementation ('com.android.support:customtabs:23.3.0') {
         exclude module: 'support-v4'
     }
+
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion Integer.parseInt(project.ANDROID_BUILD_SDK_VERSION)
     buildToolsVersion project.ANDROID_BUILD_TOOLS_VERSION
 
     defaultConfig {
         applicationId "io.branch.branchandroiddemo"
-        minSdkVersion 16
+        minSdkVersion Integer.parseInt(project.ANDROID_BUILD_TARGET_SDK_MINIMUM)
         targetSdkVersion Integer.parseInt(project.ANDROID_BUILD_TARGET_SDK_VERSION)
         versionName project.VERSION_NAME
         versionCode Integer.parseInt(project.VERSION_CODE)
+
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
     signingConfigs { release }
@@ -40,10 +46,11 @@ android {
             renderscript.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']
-        }
 
-        // Move the tests to tests/java, tests/res, etc...
-        androidTest.setRoot('tests')
+            androidTest {
+                java.srcDirs = ['androidTest']
+            }
+        }
 
         // Move the build types to build-types/<type>
         // For instance, build-types/debug/java, build-types/debug/AndroidManifest.xml, ...

--- a/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
+++ b/Branch-SDK-TestBed/src/io/branch/branchandroiddemo/MainActivity.java
@@ -17,7 +17,6 @@ import org.json.JSONObject;
 
 import java.util.Date;
 
-import io.branch.branchandroiddemo.test.BUOTestRoutines;
 import io.branch.indexing.BranchUniversalObject;
 import io.branch.referral.Branch;
 import io.branch.referral.Branch.BranchReferralInitListener;

--- a/Branch-SDK/build.gradle
+++ b/Branch-SDK/build.gradle
@@ -25,6 +25,7 @@ android {
         targetSdkVersion Integer.parseInt(project.ANDROID_BUILD_TARGET_SDK_VERSION)
         versionName project.VERSION_NAME
         versionCode Integer.parseInt(project.VERSION_CODE)
+        minSdkVersion Integer.parseInt(project.ANDROID_BUILD_TARGET_SDK_MINIMUM)
     }
 
     sourceSets {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=3.0.3
-VERSION_CODE=1
+VERSION_NAME=3.0.4
+VERSION_CODE=030004
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.
@@ -13,6 +13,7 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=branch
 POM_DEVELOPER_NAME=Branch Metrics
 
-ANDROID_BUILD_TARGET_SDK_VERSION=19
+ANDROID_BUILD_TARGET_SDK_MINIMUM=16
+ANDROID_BUILD_TARGET_SDK_VERSION=28
 ANDROID_BUILD_TOOLS_VERSION=27.0.3
-ANDROID_BUILD_SDK_VERSION=22
+ANDROID_BUILD_SDK_VERSION=28


### PR DESCRIPTION
## Reference

SDK-131 -- Update gradle compile and tools versions in prep for release

## Description
In preparation for release of v3.0.4, I noticed that many of the gradle compile/target versions were significantly out of date.   While updating these to later versions I found that unit tests no longer compiled, as the InstrumentationTestCase has been deprecated.   While updating _those_... I moved the tests out of the source folder into an androidTest suite.

## Testing Instructions
* Sample app should continue to function.

## Risk Assessment [`MEDIUM`]
I changed more than I would have like to.  I want extra eyes on this to make sure that nothing slips through the cracks.

- [X] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [x] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [x] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
