### PR TITLE
SDK-65 -- SDK Unit Testing Framework (update)

### DIFF
--- a/Branch-SDK/androidTest/io/branch/referral/BranchEventTest.java
+++ b/Branch-SDK/androidTest/io/branch/referral/BranchEventTest.java
@@ -1,6 +1,9 @@
 package io.branch.referral;
 
+import android.content.Context;
 import android.support.test.runner.AndroidJUnit4;
+
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,6 +19,8 @@ import io.branch.referral.util.CurrencyType;
  */
 @RunWith(AndroidJUnit4.class)
 public class BranchEventTest extends BranchTest {
+
+    private static final String TEST_KEY = "key_live_testkey";
 
     @Test
     public void testStandardEvent() throws Throwable {
@@ -55,7 +60,7 @@ public class BranchEventTest extends BranchTest {
 
     @Test
     public void testLogEvent() throws Throwable {
-        Branch.getInstance(getTestContext(), "key_live_testkey");
+        Branch.getInstance(getTestContext(), TEST_KEY);
 
         BRANCH_STANDARD_EVENT eventType = BRANCH_STANDARD_EVENT.PURCHASE;
         BranchEvent branchEvent = new BranchEvent(eventType);
@@ -73,7 +78,21 @@ public class BranchEventTest extends BranchTest {
     }
 
     @Test
-    public void addAllEventExtras() {
+    public void testLogEvent_queue() throws Throwable {
+        Branch.getInstance(getTestContext(), TEST_KEY);
+        initQueue(getTestContext());
+
+        BRANCH_STANDARD_EVENT eventType = BRANCH_STANDARD_EVENT.PURCHASE;
+        BranchEvent branchEvent = new BranchEvent(eventType);
+
+        ServerRequest serverRequest = logEvent(getTestContext(), branchEvent);
+        JSONObject jsonObject = serverRequest.getGetParams();
+
+        Assert.assertEquals(BRANCH_STANDARD_EVENT.PURCHASE.getName(), jsonObject.optString("name"));
+    }
+
+    @Test
+    public void addAllEventExtras() throws Throwable {
         BranchEvent event = new BranchEvent("CustomEvent");
 
         event.setTransactionID("123");
@@ -87,8 +106,6 @@ public class BranchEventTest extends BranchTest {
         event.setTax(10);
 
         event.addCustomDataProperty("test", "test value");
-
-        Assert.assertTrue(event.logEvent(getTestContext()));
     }
 
     // Dig out the variable for isStandardEvent from the BranchEvent object.
@@ -98,4 +115,84 @@ public class BranchEventTest extends BranchTest {
         f.setAccessible(true);
         return (boolean) f.get(event); //IllegalAccessException
     }
+
+    // Mark if the queue has been initialized or not
+    private boolean queueInitialized = false;
+
+    // This is an attempt to initialize the queue by adding an event and waiting for it to appear.
+    // Once it appears, we remove it.
+    // Note that adding an event to the queue the first time generates an install event as a side effect.
+    private void initQueue(Context context) throws Throwable {
+        final String EVENT_NAME = "XXXyyyXXX";
+        Branch.getInstance(getTestContext(), TEST_KEY);
+        ServerRequestQueue queue = ServerRequestQueue.getInstance(context);
+
+        // Create a test event and add it to the queue
+        BranchEvent testEvent = new BranchEvent(EVENT_NAME);
+        Assert.assertTrue(addEventToQueueAndWait(context, testEvent));
+
+        // Remove the event from the queue.  It should be the last one.
+        if (queue.getSize() > 0) {
+            int index = queue.getSize() - 1;
+            queue.removeAt(index);
+        }
+
+        // We expect that the install event is still on the queue
+        Assert.assertEquals(1, queue.getSize());
+
+        queueInitialized = true;
+    }
+
+    // Obtain the ServerRequest that is on the queue that matches the BranchEvent to be logged.
+    private ServerRequest logEvent(Context context, BranchEvent event) throws Throwable {
+        ServerRequestQueue queue = ServerRequestQueue.getInstance(context);
+        int queueSizeIn = queue.getSize();
+
+        Assert.assertTrue(addEventToQueueAndWait(context, event));
+
+        int queueSizeOut = queue.getSize();
+
+        Assert.assertEquals(queueSizeOut, (queueSizeIn + 1));
+
+        ServerRequest queuedEvent = queue.peekAt(queueSizeOut - 1);
+        Assert.assertNotNull(queuedEvent);
+
+        // Black Magic here.   In order to really find out what is going to be in this request,
+        // we need to pretend like we are updating it right before sending it out.  We obviously
+        // don't *actually* want to send this, we just want to verify that parameters are fully set.
+        queuedEvent.doFinalUpdateOnBackgroundThread();
+
+        return queuedEvent;
+    }
+
+    private boolean addEventToQueueAndWait(Context context, BranchEvent event) throws Throwable {
+        ServerRequestQueue queue = ServerRequestQueue.getInstance(context);
+        event.logEvent(context);
+
+        boolean found = false;
+        int wait_remaining = 2000;
+        final int interval = 50;
+
+        while (wait_remaining > 0) {
+            Thread.sleep(interval);
+            if (queue.getSize() > 0) {
+                int index = queue.getSize() - 1;
+
+                ServerRequest test = queue.peekAt(index);
+                JSONObject jsonObject = test.getGetParams();
+
+                String eventName = jsonObject.optString("name");
+                if (eventName.equals(event.getEventName())) {
+                    // Found it.
+                    found = true;
+                    break;
+                }
+            }
+            wait_remaining -= interval;
+        }
+
+        return found;
+    }
+
 }
+

--- a/Branch-SDK/androidTest/io/branch/referral/BranchTest.java
+++ b/Branch-SDK/androidTest/io/branch/referral/BranchTest.java
@@ -26,6 +26,7 @@ public class BranchTest {
 
     @After
     public void tearDown() {
+        Branch.shutDown();
         mContext = null;
     }
 

--- a/Branch-SDK/build.gradle
+++ b/Branch-SDK/build.gradle
@@ -19,6 +19,9 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+
+    // Unit tests with Google Ads
+    androidTestImplementation 'com.google.android.gms:play-services-ads:16.0.0'
 }
 
 android {

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -793,7 +793,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
 
         // Release these contexts immediately.
         if (branchReferral_ != null) {
-        branchReferral_.context_ = null;
+            branchReferral_.context_ = null;
         branchReferral_.currentActivityReference_ = null;
         }
 

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -774,7 +774,45 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     private static Branch initInstance(@NonNull Context context) {
         return new Branch(context.getApplicationContext());
     }
-    
+
+    // Package Private
+    // For Unit Testing, we need to reset the Branch state
+    static void shutDown() {
+        ServerRequestQueue.shutDown();
+
+        // BranchStrongMatchHelper.shutDown();
+        // BranchViewHandler.shutDown();
+        // DeepLinkRoutingValidator.shutDown();
+        // DeviceInfo.shutDown();
+        // InstallListener.shutDown();
+        // InstantAppUtil.shutDown();
+        // IntegrationValidator.shutDown();
+        // PrefHelper.shutDown();
+        // ShareLinkManager.shutDown();
+        // UniversalResourceAnalyser.shutDown();
+
+        // Release these contexts immediately.
+        if (branchReferral_ != null) {
+        branchReferral_.context_ = null;
+        branchReferral_.currentActivityReference_ = null;
+        }
+
+        // Reset all of the statics.
+        branchReferral_ = null;
+        customReferrableSettings_ = CUSTOM_REFERRABLE_SETTINGS.USE_DEFAULT;
+        bypassCurrentActivityIntentState_ = false;
+        disableInstantDeepLinking = false;
+        isActivityLifeCycleCallbackRegistered_ = false;
+        isAutoSessionMode_ = false;
+
+        isLogging_ = null;
+        isForcedSession_ = false;
+        isSimulatingInstalls_ = false;
+
+        checkInstallReferrer_ = true;
+    }
+
+
     /**
      * <p>Manually sets the {@link Boolean} value, that indicates that the Branch API connection has
      * been initialised, to false - forcing re-initialisation.</p>

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -794,7 +794,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         // Release these contexts immediately.
         if (branchReferral_ != null) {
             branchReferral_.context_ = null;
-        branchReferral_.currentActivityReference_ = null;
+            branchReferral_.currentActivityReference_ = null;
         }
 
         // Reset all of the statics.

--- a/Branch-SDK/src/io/branch/referral/ServerRequestQueue.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestQueue.java
@@ -49,6 +49,13 @@ class ServerRequestQueue {
         }
         return SharedInstance;
     }
+
+    // Package Private
+    static void shutDown() {
+        synchronized (reqQueueLockObject) {
+            SharedInstance = null;
+        }
+    }
     
     /**
      * <p>The main constructor of the ServerRequestQueue class is private because the class uses the

--- a/Branch-SDK/src/io/branch/referral/util/BranchEvent.java
+++ b/Branch-SDK/src/io/branch/referral/util/BranchEvent.java
@@ -197,6 +197,11 @@ public class BranchEvent {
         return this;
     }
 
+    // Undocumented
+    public String getEventName() {
+        return eventName;
+    }
+
     /**
      * Logs this BranchEvent to Branch for tracking and analytics
      *


### PR DESCRIPTION
## Reference
SDK-65 -- Unit Testing Framework needed

## Description
To get unit tests to pass as a suite, we need a way to gracefully "shutDown" the Branch SDK.   There are static variables that do not reset between tests in the suite.   The shutDown sequence is only used by the unitTests.

While there were changes to Branch.java and to ServerRequestQueue, these changes are "Package Private" and not accessible to the general public.

There was a single public change to BranchEvent to expose the "Name" variable, needed for better testing.

Due to the asynchronous nature of the event queue, a lot of effort was put into the tests to be able to put an event on the queue, and examine it after it has been updated.

## Testing Instructions
* Sample app should continue to function.
* Unit tests should all pass

## Risk Assessment [`LOW`]
Adding more unit tests can only be a good thing.

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
