### PR TITLE
INTENG-4676 -- No deep link registered when push notification received while app in foreground

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -1308,12 +1308,12 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     }
 
     public boolean reInitSession(Activity activity, BranchUniversalReferralInitListener callback) {
-        getFinalIntent(activity, true);
+        handleActivityIntent(activity, true);
         return  initSession(callback);
     }
 
     public boolean reInitSession(Activity activity, BranchReferralInitListener callback) {
-        getFinalIntent(activity, true);
+        handleActivityIntent(activity, true);
         return  initSession(callback);
     }
 
@@ -2658,21 +2658,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         
         @Override
         public void onActivityResumed(Activity activity) {
-            // Need to check here again for session restart request in case the intent is created while the activity is already running
-            if (checkIntentForSessionRestart(activity.getIntent())) {
-                initState_ = SESSION_STATE.UNINITIALISED;
-                startSession(activity);
-            }
-            currentActivityReference_ = new WeakReference<>(activity);
-
-            // if the intent state is bypassed from the last activity as it was closed before onResume, we need to skip this with the current
-            // activity also to make sure we do not override the intent data
-            if (handleDelayedNewIntents_ && !bypassCurrentActivityIntentState_) {
-                intentState_ = INTENT_STATE.READY;
-                // Grab the intent only for first activity unless this activity is intent to  force new session
-                boolean grabIntentParams = activity.getIntent() != null && initState_ != SESSION_STATE.INITIALISED;
-                onIntentReady(activity, grabIntentParams);
-            }
+            handleActivityIntent(activity, false);
         }
         
         @Override
@@ -2707,7 +2693,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         
     }
 
-    private void getFinalIntent(Activity activity, boolean forceRestart) {
+    private void handleActivityIntent(Activity activity, boolean forceRestart) {
         // Need to check here again for session restart request in case the intent is created while the activity is already running
         if (forceRestart || checkIntentForSessionRestart(activity.getIntent())) {
             initState_ = SESSION_STATE.UNINITIALISED;


### PR DESCRIPTION
## Reference
INTENG-4676 -- No deep link registered when push notification received while app in foreground

## Description
When an app is in the foreground, and receives a new push notification, the new notification is not handled by Branch correctly.  

This change requires the customer to make a new call into the SDK to reinitialize the session when its activity receives an `onNewIntent()` message.

    @Override
    protected void onNewIntent(Intent intent) {
        super.onNewIntent(intent);

        setIntent(intent);
        Branch.getInstance().reInitSession(this, myReferralInitListener);
    }

The lifecycle is such that onNewIntent() is called by the OS before onResume -- which will then pick up the new intent correctly.

## Testing Instructions
* Sample app should continue to function.
* Unit tests should all pass

## Notes
* If this PR is accepted, this will require documentation changes to follow.
* Note that the activity should still do the initial initialization of the session in `onStart()` per documentation.

## Risk Assessment [`HIGH`]
The code changes around session management should be reviewed with care.

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)