### PR TITLE
SDK-170 -- Update for Global opt-out for customer

### DIFF
--- a/Branch-SDK/androidTest/io/branch/referral/BranchGAIDTest.java
+++ b/Branch-SDK/androidTest/io/branch/referral/BranchGAIDTest.java
@@ -23,7 +23,7 @@ import io.branch.referral.util.CommerceEvent;
  [-] ServerRequestLogout.java                   testLogout()
  [-] ServerRequestPing.java                     testPing()
  [X] ServerRequestRActionCompleted.java         testCommerceEvent()
- [-] ServerRequestRedeemRewards.java            testRedeemRewards()
+ [X] ServerRequestRedeemRewards.java            testRedeemRewards()
  [-] ServerRequestRegisterClose.java            testClose()
  [ ] ServerRequestRegisterInstall.java
  [ ] ServerRequestRegisterOpen.java
@@ -103,8 +103,6 @@ public class BranchGAIDTest extends BranchEventTest {
 
     @Test
     public void testRedeemAwards_hasGAIDv1() throws Throwable {
-        // TODO: redeemRewards() does not have GAID
-
         Branch.getInstance(getTestContext(), TEST_KEY);
         initQueue(getTestContext());
 
@@ -118,14 +116,12 @@ public class BranchGAIDTest extends BranchEventTest {
         Assert.assertNotNull(serverRequest);
         doFinalUpdate(serverRequest);
 
-        Assert.assertFalse(hasV1GAID(serverRequest));
+        Assert.assertTrue(hasV1GAID(serverRequest));
         Assert.assertFalse(hasV2GAID(serverRequest));
     }
 
     @Test
     public void testCreditHistory_hasGAIDv1() throws Throwable {
-        // TODO: getCreditHistory() does not have GAID
-
         Branch.getInstance(getTestContext(), TEST_KEY);
         initQueue(getTestContext());
 
@@ -135,14 +131,12 @@ public class BranchGAIDTest extends BranchEventTest {
         Assert.assertNotNull(serverRequest);
         doFinalUpdate(serverRequest);
 
-        Assert.assertFalse(hasV1GAID(serverRequest));
+        Assert.assertTrue(hasV1GAID(serverRequest));
         Assert.assertFalse(hasV2GAID(serverRequest));
     }
 
     @Test
     public void testIdentity_hasGAIDv1() throws Throwable {
-        // TODO: setIdentity() does not have GAID
-
         Branch.getInstance(getTestContext(), TEST_KEY);
         initQueue(getTestContext());
 
@@ -152,7 +146,7 @@ public class BranchGAIDTest extends BranchEventTest {
         Assert.assertNotNull(serverRequest);
         doFinalUpdate(serverRequest);
 
-        Assert.assertFalse(hasV1GAID(serverRequest));
+        Assert.assertTrue(hasV1GAID(serverRequest));
         Assert.assertFalse(hasV2GAID(serverRequest));
     }
 

--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -210,13 +210,13 @@ public abstract class ServerRequest {
     /**
      * <p>
      * Specifies whether this request need to be updated with Google Ads Id and LAT value
-     * By default update GAds params update is turned off. Override this on request which need to have GAds params
+     * By default update GAds params update is turned on. Override this on request which need to have GAds params
      * </p>
      *
      * @return A {@link Boolean} with value true if this request need GAds params
      */
     public boolean isGAdsParamsRequired() {
-        return false;
+        return true;
     }
     
     /**

--- a/Branch-SDK/src/io/branch/referral/ServerRequestActionCompleted.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestActionCompleted.java
@@ -86,11 +86,6 @@ class ServerRequestActionCompleted extends ServerRequest {
     }
 
     @Override
-    public boolean isGAdsParamsRequired() {
-        return true;
-    }
-
-    @Override
     public void handleFailure(int statusCode, String causeMsg) {
         //No implementation on purpose
     }

--- a/Branch-SDK/src/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestInitSession.java
@@ -65,11 +65,6 @@ abstract class ServerRequestInitSession extends ServerRequest {
     public abstract boolean hasCallBack();
 
     @Override
-    public boolean isGAdsParamsRequired() {
-        return true; //Session start requests need GAds params
-    }
-
-    @Override
     protected boolean shouldUpdateLimitFacebookTracking() {
         return true;
     }

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRActionCompleted.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRActionCompleted.java
@@ -87,11 +87,6 @@ class ServerRequestRActionCompleted extends ServerRequest {
     }
 
     @Override
-    public boolean isGAdsParamsRequired() {
-        return true;
-    }
-
-    @Override
     public void handleFailure(int statusCode, String causeMsg) {
         //No implementation on purpose
     }

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterView.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterView.java
@@ -156,9 +156,4 @@ class ServerRequestRegisterView extends ServerRequest {
 
         return contentObject;
     }
-
-    @Override
-    public boolean isGAdsParamsRequired() {
-        return true;
-    }
 }

--- a/Branch-SDK/src/io/branch/referral/util/BranchEvent.java
+++ b/Branch-SDK/src/io/branch/referral/util/BranchEvent.java
@@ -289,11 +289,6 @@ public class BranchEvent {
         }
 
         @Override
-        public boolean isGAdsParamsRequired() {
-            return true;
-        }
-    
-        @Override
         protected boolean shouldUpdateLimitFacebookTracking() {
             return true;
         }


### PR DESCRIPTION
## Reference
SDK-170 -- Update for Global opt-out for customer

## Description
GAID (when available) is only sent on certain messages.   To allow customers to opt-out of receiving messages, we want to make sure that this identifier is present in all requests.

## Testing Instructions
* Sample app should continue to function.
* Unit tests should all pass

## Notes
I was using a different branch to attempt to *prove* that the message was present in all cases, however that became a much larger PR and we can address better testing methodology in the future.

## Risk Assessment [`MEDIUM`]
The code changes are minor, however special attention should be taken to ensure that the new events are correct per the PRD.

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)