### PR TITLE
SDK-157 -- setDebug issues

### DIFF
--- a/Branch-SDK/androidTest/AndroidManifest.xml
+++ b/Branch-SDK/androidTest/AndroidManifest.xml
@@ -9,7 +9,8 @@
     <application>
         <activity android:name=".mock.MockActivity" />
 
-        <!-- The Branch Key for testing.  Do not use this key for production applications. -->
+        <!-- The Branch Key for testing.  Do not use these keys for production applications. -->
         <meta-data android:name="io.branch.sdk.BranchKey" android:value="key_live_testing_only" />
+        <meta-data android:name="io.branch.sdk.BranchKey.test" android:value="key_test_testing_only" />
     </application>
 </manifest>

--- a/Branch-SDK/androidTest/AndroidManifest.xml
+++ b/Branch-SDK/androidTest/AndroidManifest.xml
@@ -10,6 +10,7 @@
         <activity android:name=".mock.MockActivity" />
 
         <!-- The Branch Key for testing.  Do not use these keys for production applications. -->
+        <meta-data android:name="io.branch.sdk.TestMode" android:value="false" />
         <meta-data android:name="io.branch.sdk.BranchKey" android:value="key_live_testing_only" />
         <meta-data android:name="io.branch.sdk.BranchKey.test" android:value="key_test_testing_only" />
     </application>

--- a/Branch-SDK/androidTest/io/branch/referral/DebugTest.java
+++ b/Branch-SDK/androidTest/io/branch/referral/DebugTest.java
@@ -1,0 +1,67 @@
+package io.branch.referral;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class DebugTest extends BranchTest {
+
+    @Test
+    public void testDebugState() {
+        /*
+        DebugMode         TestMode          isTestModeEnabled     isDebugModeEnabled
+           0                  0                false                 false
+           0                  1                true                  true
+           1                  0                false                 true
+           1                  1                true                  true
+        */
+
+        Assert.assertFalse(BranchUtil.isDebugEnabled());
+        Assert.assertFalse(BranchUtil.isTestModeEnabled());
+
+        // Debug Mode
+        Branch.enableDebugMode();
+        Assert.assertTrue(BranchUtil.isDebugEnabled());
+        Assert.assertFalse(BranchUtil.isTestModeEnabled());
+
+        Branch.disableDebugMode();
+        Assert.assertFalse(BranchUtil.isDebugEnabled());
+        Assert.assertFalse(BranchUtil.isTestModeEnabled());
+
+        // Test Mode
+        Branch.enableTestMode();
+        Assert.assertTrue(BranchUtil.isDebugEnabled());
+        Assert.assertTrue(BranchUtil.isTestModeEnabled());
+
+        Branch.disableTestMode();
+        Assert.assertFalse(BranchUtil.isDebugEnabled());
+        Assert.assertFalse(BranchUtil.isTestModeEnabled());
+
+        // Both Debug and Test Mode (variation A, debug before test)
+        Branch.enableDebugMode();
+        Branch.enableTestMode();
+        Assert.assertTrue(BranchUtil.isDebugEnabled());
+        Assert.assertTrue(BranchUtil.isTestModeEnabled());
+
+        Branch.disableDebugMode();
+        Assert.assertTrue(BranchUtil.isDebugEnabled());     // Per Javadoc, debug is enabled if either debug or test is enabled.
+        Assert.assertTrue(BranchUtil.isTestModeEnabled());
+
+        Branch.disableTestMode();
+        Assert.assertFalse(BranchUtil.isDebugEnabled());
+        Assert.assertFalse(BranchUtil.isTestModeEnabled());
+
+        // Both Debug and Test Mode (variation B, test before debug)
+        Branch.enableTestMode();
+        Branch.enableDebugMode();
+        Assert.assertTrue(BranchUtil.isDebugEnabled());
+        Assert.assertTrue(BranchUtil.isTestModeEnabled());
+
+        Branch.disableTestMode();
+        Assert.assertFalse(BranchUtil.isTestModeEnabled());
+        Assert.assertFalse(BranchUtil.isDebugEnabled());    // Per Javadoc, turning off test mode also turns off debug mode.
+    }
+}

--- a/Branch-SDK/androidTest/io/branch/referral/DebugTest.java
+++ b/Branch-SDK/androidTest/io/branch/referral/DebugTest.java
@@ -8,17 +8,16 @@ import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class DebugTest extends BranchTest {
+    /*
+    DebugMode         TestMode          isTestModeEnabled     isDebugModeEnabled
+       0                  0                false                 false
+       0                  1                true                  true
+       1                  0                false                 true
+       1                  1                true                  true
+    */
 
     @Test
     public void testDebugState() {
-        /*
-        DebugMode         TestMode          isTestModeEnabled     isDebugModeEnabled
-           0                  0                false                 false
-           0                  1                true                  true
-           1                  0                false                 true
-           1                  1                true                  true
-        */
-
         Assert.assertFalse(BranchUtil.isDebugEnabled());
         Assert.assertFalse(BranchUtil.isTestModeEnabled());
 
@@ -63,5 +62,43 @@ public class DebugTest extends BranchTest {
         Branch.disableTestMode();
         Assert.assertFalse(BranchUtil.isTestModeEnabled());
         Assert.assertFalse(BranchUtil.isDebugEnabled());    // Per Javadoc, turning off test mode also turns off debug mode.
+    }
+
+    @Test
+    public void testTestModeA() {
+        // Test Mode should be off to start
+        Assert.assertFalse(BranchUtil.isTestModeEnabled());
+
+        // Test Mode should still be off after this check (check has a side effect)
+        Assert.assertFalse(BranchUtil.checkTestMode(getTestContext()));
+
+        // Enable Test Mode after check
+        Branch.enableTestMode();
+        Assert.assertTrue(BranchUtil.isTestModeEnabled());
+
+        // Assert that checking for test mode is also now true
+        Assert.assertTrue(BranchUtil.checkTestMode(getTestContext()));
+    }
+
+    @Test
+    public void testTestModeB() {
+        // Test Mode should be off to start
+        Assert.assertFalse(BranchUtil.isTestModeEnabled());
+
+        // Enable Test Mode before check
+        Branch.enableTestMode();
+        Assert.assertTrue(BranchUtil.isTestModeEnabled());
+
+        // Test Mode should still be on after this check (check has a side effect)
+        Assert.assertTrue(BranchUtil.checkTestMode(getTestContext()));
+
+        // Assert that this test is also still true
+        Assert.assertTrue(BranchUtil.isTestModeEnabled());
+
+        // Now turn off test mode and check
+        Branch.disableTestMode();
+
+        Assert.assertFalse(BranchUtil.isTestModeEnabled());
+        Assert.assertFalse(BranchUtil.checkTestMode(getTestContext()));
     }
 }

--- a/Branch-SDK/androidTest/io/branch/referral/KeyTest.java
+++ b/Branch-SDK/androidTest/io/branch/referral/KeyTest.java
@@ -1,0 +1,33 @@
+package io.branch.referral;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class KeyTest extends BranchTest {
+
+    @Test
+    public void testManifestKeys() {
+        Assert.assertFalse(BranchUtil.isDebugEnabled());
+        Assert.assertFalse(BranchUtil.isTestModeEnabled());
+
+        String branchKey = BranchUtil.readBranchKey(getTestContext());
+        Assert.assertTrue(branchKey.startsWith("key_live"));
+
+        Branch.enableTestMode();
+        branchKey = BranchUtil.readBranchKey(getTestContext());
+        Assert.assertTrue(branchKey.startsWith("key_test"));
+    }
+
+    @Test
+    public void testAutoInstanceWithKey() {
+        final String expectedKey = "key_XXX";
+        Branch branch = Branch.getAutoInstance(getTestContext(), expectedKey);
+
+        final String actualKey = PrefHelper.getInstance(getTestContext()).getBranchKey();
+        Assert.assertEquals(expectedKey, actualKey);
+    }
+}

--- a/Branch-SDK/src/io/branch/indexing/AppIndexingHelper.java
+++ b/Branch-SDK/src/io/branch/indexing/AppIndexingHelper.java
@@ -35,10 +35,10 @@ class AppIndexingHelper {
                     firebaseUserActionsInstance = FirebaseUserActions.getInstance();
                 } catch (NoClassDefFoundError ignore) {
                     // Expected when Firebase app indexing dependency is not available
-                    PrefHelper.Debug("BranchSDK", "Firebase app indexing is not available. Please consider enabling Firebase app indexing for your app for better indexing experience with Google.");
+                    PrefHelper.Debug("Firebase app indexing is not available. Please consider enabling Firebase app indexing for your app for better indexing experience with Google.");
                 } catch (Throwable ignore) {
                     // unexpected exception
-                    PrefHelper.Debug("BranchSDK", "Failed to index your contents using Firebase. Please make sure Firebase  is enabled and initialised in your app");
+                    PrefHelper.Debug("Failed to index your contents using Firebase. Please make sure Firebase  is enabled and initialised in your app");
                 }
                 String contentUrl;
                 if (linkProperties == null) {
@@ -46,7 +46,7 @@ class AppIndexingHelper {
                 } else {
                     contentUrl = buo.getShortUrl(context, linkProperties);
                 }
-                PrefHelper.Debug("BranchSDK", "Indexing BranchUniversalObject with Google using URL " + contentUrl);
+                PrefHelper.Debug("Indexing BranchUniversalObject with Google using URL " + contentUrl);
                 if (!TextUtils.isEmpty(contentUrl)) {
                     try {
                         if (firebaseUserActionsInstance != null) {
@@ -56,7 +56,7 @@ class AppIndexingHelper {
                             listOnGoogleSearch(contentUrl, context, buo);
                         }
                     } catch (Throwable e) {
-                        PrefHelper.Debug("BranchSDK", "Branch Warning: Unable to list your content in Google search. Please make sure you have added latest Firebase app indexing SDK to your project dependencies.");
+                        PrefHelper.Debug("Warning: Unable to list your content in Google search. Please make sure you have added latest Firebase app indexing SDK to your project dependencies.");
                     }
                 }
             }
@@ -74,14 +74,14 @@ class AppIndexingHelper {
                     } else {
                         contentUrl = buo.getShortUrl(context, linkProperties);
                     }
-                    PrefHelper.Debug("BranchSDK", "Removing indexed BranchUniversalObject with link " + contentUrl);
+                    PrefHelper.Debug("Removing indexed BranchUniversalObject with link " + contentUrl);
                     FirebaseAppIndex.getInstance().remove(contentUrl);
                 } catch (NoClassDefFoundError ignore) {
                     // Expected when Firebase app indexing dependency is not available
-                    PrefHelper.Debug("BranchSDK", "Failed to remove the BranchUniversalObject from Firebase local indexing. Please make sure Firebase is enabled and initialised in your app");
+                    PrefHelper.Debug("Failed to remove the BranchUniversalObject from Firebase local indexing. Please make sure Firebase is enabled and initialised in your app");
                 } catch (Throwable ignore) {
                     // unexpected exception
-                    PrefHelper.Debug("BranchSDK", "Failed to index your contents using Firebase. Please make sure Firebase is enabled and initialised in your app");
+                    PrefHelper.Debug("Failed to index your contents using Firebase. Please make sure Firebase is enabled and initialised in your app");
                 }
             }
         }).run();

--- a/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
+++ b/Branch-SDK/src/io/branch/indexing/BranchUniversalObject.java
@@ -7,7 +7,6 @@ import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
-import android.util.Log;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -23,6 +22,7 @@ import io.branch.referral.BranchError;
 import io.branch.referral.BranchShortLinkBuilder;
 import io.branch.referral.BranchUtil;
 import io.branch.referral.Defines;
+import io.branch.referral.PrefHelper;
 import io.branch.referral.util.BRANCH_STANDARD_EVENT;
 import io.branch.referral.util.BranchEvent;
 import io.branch.referral.util.ContentMetadata;
@@ -647,7 +647,7 @@ public class BranchUniversalObject implements Parcelable {
             if (callback != null) {
                 callback.onLinkShareResponse(null, null, new BranchError("Trouble sharing link. ", BranchError.ERR_BRANCH_NOT_INSTANTIATED));
             } else {
-                Log.e("BranchSDK", "Sharing error. Branch instance is not created yet. Make sure you have initialised Branch.");
+                PrefHelper.Debug("Sharing error. Branch instance is not created yet. Make sure you have initialised Branch.");
             }
         } else {
             Branch.ShareLinkBuilder shareLinkBuilder = new Branch.ShareLinkBuilder(activity, getLinkBuilder(activity, linkProperties));

--- a/Branch-SDK/src/io/branch/referral/BranchApp.java
+++ b/Branch-SDK/src/io/branch/referral/BranchApp.java
@@ -31,7 +31,7 @@ public class BranchApp extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        if (BranchUtil.isTestModeEnabled(this) == false) {
+        if (BranchUtil.checkTestMode(this) == false) {
             Branch.getInstance(this);
         } else {
             Branch.getTestInstance(this);

--- a/Branch-SDK/src/io/branch/referral/BranchStrongMatchHelper.java
+++ b/Branch-SDK/src/io/branch/referral/BranchStrongMatchHelper.java
@@ -80,7 +80,7 @@ class BranchStrongMatchHelper {
         } else {
             try {
                 if (deviceInfo.getHardwareID() != null) {
-                    final Uri strongMatchUri = buildStrongMatchUrl(cookieMatchDomain, deviceInfo, prefHelper, systemObserver, context);
+                    final Uri strongMatchUri = buildStrongMatchUrl(cookieMatchDomain, deviceInfo, prefHelper, systemObserver);
                     if (strongMatchUri != null) {
                         timeOutHandler_.postDelayed(new Runnable() {
                             @Override
@@ -155,7 +155,7 @@ class BranchStrongMatchHelper {
         }
     }
 
-    private Uri buildStrongMatchUrl(String matchDomain, DeviceInfo deviceInfo, PrefHelper prefHelper, SystemObserver systemObserver, Context context) {
+    private Uri buildStrongMatchUrl(String matchDomain, DeviceInfo deviceInfo, PrefHelper prefHelper, SystemObserver systemObserver) {
         Uri strongMatchUri = null;
         if (!TextUtils.isEmpty(matchDomain)) {
             String uriString = "https://" + matchDomain + "/_strong_match?os=" + deviceInfo.getOsName();
@@ -164,7 +164,7 @@ class BranchStrongMatchHelper {
             String hardwareIDTypeVal = deviceInfo.isHardwareIDReal() ? Defines.Jsonkey.HardwareIDTypeVendor.getKey() : Defines.Jsonkey.HardwareIDTypeRandom.getKey();
             uriString += "&" + Defines.Jsonkey.HardwareIDType.getKey() + "=" + hardwareIDTypeVal;
             // Add GAID if available
-            if (systemObserver.GAIDString_ != null && !BranchUtil.isTestModeEnabled(context)) {
+            if (systemObserver.GAIDString_ != null && !BranchUtil.isTestModeEnabled()) {
                 uriString += "&" + Defines.Jsonkey.GoogleAdvertisingID.getKey() + "=" + systemObserver.GAIDString_;
             }
             // Add device finger print if available

--- a/Branch-SDK/src/io/branch/referral/BranchUrlBuilder.java
+++ b/Branch-SDK/src/io/branch/referral/BranchUrlBuilder.java
@@ -1,9 +1,7 @@
 package io.branch.referral;
 
 import android.content.Context;
-import android.util.Log;
 
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -142,7 +140,7 @@ abstract class BranchUrlBuilder<T extends BranchUrlBuilder> {
             if (callback != null) {
                 callback.onLinkCreate(null, new BranchError("session has not been initialized", BranchError.ERR_NO_SESSION));
             }
-            Log.i("BranchSDK", "Branch Warning: User session has not been initialized");
+            PrefHelper.Debug("Warning: User session has not been initialized");
         }
     }
 

--- a/Branch-SDK/src/io/branch/referral/BranchUtil.java
+++ b/Branch-SDK/src/io/branch/referral/BranchUtil.java
@@ -36,6 +36,13 @@ public class BranchUtil {
     // Only need to check once for Manifest Flags
     private static Boolean isManifestTestModeEnabled = null;
 
+    // Package Private
+    static void shutDown() {
+        isCustomDebugEnabled_ = false;
+        isTestModeEnabled_ = false;
+        isManifestTestModeEnabled = null;
+    }
+
     /**
      * Get the value of "io.branch.sdk.TestMode" entry in application manifest or from String res.
      * This will also set the value of {@link BranchUtil#isTestModeEnabled()}
@@ -44,7 +51,8 @@ public class BranchUtil {
      * false if "io.branch.sdk.TestMode" is not added in the manifest or String res.
      */
     static boolean checkTestMode(Context context) {
-        if (isManifestTestModeEnabled == null) {
+        // Test Mode can be enabled independently of checking the manifest.
+        if (!isTestModeEnabled_ && isManifestTestModeEnabled == null) {
             String testModeKey = "io.branch.sdk.TestMode";
             try {
                 final ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);

--- a/Branch-SDK/src/io/branch/referral/ExtendedAnswerProvider.java
+++ b/Branch-SDK/src/io/branch/referral/ExtendedAnswerProvider.java
@@ -1,7 +1,6 @@
 package io.branch.referral;
 
 import android.text.TextUtils;
-import android.util.Log;
 
 import com.crashlytics.android.answers.shim.AnswersOptionalLogger;
 import com.crashlytics.android.answers.shim.KitEvent;

--- a/Branch-SDK/src/io/branch/referral/InstallListener.java
+++ b/Branch-SDK/src/io/branch/referral/InstallListener.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.RemoteException;
 import android.text.TextUtils;
-import android.util.Log;
 
 import com.android.installreferrer.api.InstallReferrerClient;
 import com.android.installreferrer.api.InstallReferrerStateListener;
@@ -121,7 +120,7 @@ public class InstallListener extends BroadcastReceiver {
                                         onReferrerClientFinished(context_, rawReferrer, clickTimeStamp, installBeginTimeStamp);
                                     }
                                 } catch (RemoteException ex) {
-                                    PrefHelper.Debug("BranchSDK", ex.getMessage());
+                                    PrefHelper.Debug("onInstallReferrerSetupFinished() Exception: " + ex.getMessage());
                                     onReferrerClientError();
                                 }
                                 break;
@@ -150,7 +149,7 @@ public class InstallListener extends BroadcastReceiver {
                 });
                 isReferrerClientAvailable = true;
             } catch (Throwable ex) {
-                PrefHelper.Debug("BranchSDK", ex.getMessage());
+                PrefHelper.Debug("ReferrerClientWrapper Exception: " + ex.getMessage());
             }
             return isReferrerClientAvailable;
         }
@@ -203,7 +202,7 @@ public class InstallListener extends BroadcastReceiver {
                 e.printStackTrace();
             } catch (IllegalArgumentException e) {
                 e.printStackTrace();
-                Log.w("BranchSDK", "Illegal characters in url encoded string");
+                PrefHelper.Debug("Illegal characters in url encoded string");
             }
         }
     }

--- a/Branch-SDK/src/io/branch/referral/InstantAppUtil.java
+++ b/Branch-SDK/src/io/branch/referral/InstantAppUtil.java
@@ -68,14 +68,10 @@ class InstantAppUtil {
     @SuppressWarnings("ConstantConditions")
     static boolean doShowInstallPrompt(@NonNull Activity activity, int requestCode, @Nullable String referrer) {
         if (activity == null) {
-            if (Branch.isLogging_ != null && Branch.isLogging_) {
-                Log.e("BranchSDK", "Unable to show install prompt. Activity is null");
-            }
+            Log.e("BranchSDK", "Unable to show install prompt. Activity is null");
             return false;
         } else if (!isInstantApp(activity)) {
-            if (Branch.isLogging_ != null && Branch.isLogging_) {
-                Log.e("BranchSDK", "Unable to show install prompt. Application is not an instant app");
-            }
+            Log.e("BranchSDK", "Unable to show install prompt. Application is not an instant app");
             return false;
         } else {
             Intent intent = (new Intent("android.intent.action.VIEW")).setPackage("com.android.vending").addCategory("android.intent.category.DEFAULT")

--- a/Branch-SDK/src/io/branch/referral/InstantAppUtil.java
+++ b/Branch-SDK/src/io/branch/referral/InstantAppUtil.java
@@ -9,7 +9,6 @@ import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
-import android.util.Log;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -68,10 +67,10 @@ class InstantAppUtil {
     @SuppressWarnings("ConstantConditions")
     static boolean doShowInstallPrompt(@NonNull Activity activity, int requestCode, @Nullable String referrer) {
         if (activity == null) {
-            Log.e("BranchSDK", "Unable to show install prompt. Activity is null");
+            PrefHelper.Debug("Unable to show install prompt. Activity is null");
             return false;
         } else if (!isInstantApp(activity)) {
-            Log.e("BranchSDK", "Unable to show install prompt. Application is not an instant app");
+            PrefHelper.Debug("Unable to show install prompt. Application is not an instant app");
             return false;
         } else {
             Intent intent = (new Intent("android.intent.action.VIEW")).setPackage("com.android.vending").addCategory("android.intent.category.DEFAULT")

--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -1147,14 +1147,19 @@ public class PrefHelper {
     /**
      * <p>Creates a <b>Debug</b> message in the debugger. If debugging is disabled, this will fail silently.</p>
      *
-     * @param tag     A {@link String} value specifying the logging tag to use for the message.
      * @param message A {@link String} value containing the debug message to record.
      */
-    public static void Debug(String tag, String message) {
+    public static void Debug(String message) {
         if (BranchUtil.isDebugEnabled()) {
-            if(message != null) {
-                Log.i(tag,  message);
+            if (!TextUtils.isEmpty(message)) {
+                Log.i("BranchSDK", message);
             }
+        }
+    }
+
+    public static void LogAlways(String message) {
+        if (!TextUtils.isEmpty(message)) {
+            Log.i("BranchSDK", message);
         }
     }
 }

--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -4,9 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
-import android.content.pm.ApplicationInfo;
-import android.content.pm.PackageManager;
-import android.content.res.Resources;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
@@ -33,11 +30,6 @@ public class PrefHelper {
     private static final String BRANCH_BASE_URL_V2 = "https://api2.branch.io/";
     private static final String BRANCH_BASE_URL_V1 = "https://api.branch.io/";
 
-    /**
-     * {@link Boolean} value that enables/disables Branch developer external debug mode.
-     */
-    private static boolean BNC_Dev_Debug = false;
-    
     /**
      * A {@link String} value used where no string value is available.
      */
@@ -136,11 +128,6 @@ public class PrefHelper {
     private final JSONObject installMetadata;
     
     /**
-     * Reference of application {@link Context}, normally the base context of the application.
-     */
-    private Context context_;
-    
-    /**
      * Branch Content discovery data
      */
     private static JSONObject savedAnalyticsData_;
@@ -156,7 +143,6 @@ public class PrefHelper {
         this.appSharedPrefs_ = context.getSharedPreferences(SHARED_PREF_FILE,
                 Context.MODE_PRIVATE);
         this.prefsEditor_ = this.appSharedPrefs_.edit();
-        this.context_ = context;
         this.requestMetadata = new JSONObject();
         this.installMetadata = new JSONObject();
     }
@@ -180,12 +166,10 @@ public class PrefHelper {
     // Package Private
     static void shutDown() {
         if (prefHelper_ != null) {
-            prefHelper_.context_ = null;
             prefHelper_.prefsEditor_ = null;
         }
 
         // Reset all of the statics.
-        BNC_Dev_Debug = false;
         Branch_Key = null;
         savedAnalyticsData_ = null;
         prefHelper_ = null;
@@ -313,39 +297,6 @@ public class PrefHelper {
             Branch_Key = getString(KEY_BRANCH_KEY);
         }
         return Branch_Key;
-    }
-    
-    public String readBranchKey(boolean isLive) {
-        String branchKey = null;
-        String metaDataKey = isLive ? "io.branch.sdk.BranchKey" : "io.branch.sdk.BranchKey.test";
-        if (!isLive) {
-            setExternDebug();
-        }
-        
-        try {
-            final ApplicationInfo ai = context_.getPackageManager().getApplicationInfo(context_.getPackageName(), PackageManager.GET_META_DATA);
-            if (ai.metaData != null) {
-                branchKey = ai.metaData.getString(metaDataKey);
-                if (branchKey == null && !isLive) {
-                    branchKey = ai.metaData.getString("io.branch.sdk.BranchKey");
-                }
-            }
-        } catch (final Exception ignore) {
-        }
-        
-        // If Branch key is not specified in the manifest check String resource
-        if (TextUtils.isEmpty(branchKey)) {
-            try {
-                Resources resources = context_.getResources();
-                branchKey = resources.getString(resources.getIdentifier(metaDataKey, "string", context_.getPackageName()));
-            } catch (Exception ignore) {
-            }
-        }
-        if (branchKey == null) {
-            branchKey = NO_STRING_VALUE;
-        }
-        
-        return branchKey;
     }
     
     /**
@@ -1159,23 +1110,6 @@ public class PrefHelper {
         prefHelper_.prefsEditor_.apply();
     }
     
-    /**
-     * <p>Switches external debugging on.</p>
-     */
-    public void setExternDebug() {
-        BNC_Dev_Debug = true;
-    }
-    
-    /**
-     * <p>Gets the value of the debug status {@link Boolean} value.</p>
-     *
-     * @return A {@link Boolean} value indicating the current state of external debugging.
-     */
-    public boolean getExternDebug() {
-        return BNC_Dev_Debug;
-    }
-    
-    
     public void setRequestMetadata(@NonNull String key, @NonNull String value) {
         if (key == null) {
             return;
@@ -1217,11 +1151,9 @@ public class PrefHelper {
      * @param message A {@link String} value containing the debug message to record.
      */
     public static void Debug(String tag, String message) {
-        if ((Branch.isLogging_ == null && BNC_Dev_Debug) || (Branch.isLogging_ != null && Branch.isLogging_)) {
+        if (BranchUtil.isDebugEnabled()) {
             if(message != null) {
                 Log.i(tag,  message);
-            } else {
-                Log.i(tag,  "An error occurred. Unable to print the log message");
             }
         }
     }

--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -188,11 +188,11 @@ public abstract class ServerRequest {
             try {
                 JSONObject userDataObj = new JSONObject();
                 params_.put(Defines.Jsonkey.UserData.getKey(), userDataObj);
-                DeviceInfo.getInstance(prefHelper_.getExternDebug(), systemObserver_, disableAndroidIDFetch_).updateRequestWithUserData(context_, prefHelper_, userDataObj);
+                DeviceInfo.getInstance(BranchUtil.isDebugEnabled(), systemObserver_, disableAndroidIDFetch_).updateRequestWithUserData(context_, prefHelper_, userDataObj);
             } catch (JSONException ignore) {
             }
         } else {
-            DeviceInfo.getInstance(prefHelper_.getExternDebug(), systemObserver_, disableAndroidIDFetch_).updateRequestWithDeviceParams(params_);
+            DeviceInfo.getInstance(BranchUtil.isDebugEnabled(), systemObserver_, disableAndroidIDFetch_).updateRequestWithDeviceParams(params_);
         }
     }
     
@@ -493,7 +493,7 @@ public abstract class ServerRequest {
         updateDeviceInfo();
         //Google ADs ID  and LAT value are updated using reflection. These method need background thread
         //So updating them for install and open on background thread.
-        if (isGAdsParamsRequired() && !BranchUtil.isTestModeEnabled(context_)) {
+        if (isGAdsParamsRequired() && !BranchUtil.isTestModeEnabled()) {
             updateGAdsParams();
         }
     }

--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -6,7 +6,6 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.text.TextUtils;
-import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -17,7 +16,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
 
 /**
  * Abstract class defining the structure of a Branch Server request.
@@ -457,7 +455,7 @@ public abstract class ServerRequest {
             }
             params_.put(Defines.Jsonkey.Metadata.getKey(), metadata);
         } catch (JSONException e) {
-            Log.e("BranchSDK", "Could not merge metadata, ignoring user metadata.");
+           PrefHelper.Debug("Could not merge metadata, ignoring user metadata.");
         }
     }
     
@@ -508,6 +506,12 @@ public abstract class ServerRequest {
     
     protected boolean doesAppHasInternetPermission(Context context) {
         int result = context.checkCallingOrSelfPermission(Manifest.permission.INTERNET);
+        boolean permissionGranted = (result == PackageManager.PERMISSION_GRANTED);
+
+        if (!permissionGranted) {
+            PrefHelper.Debug("Trouble executing your request. Please add 'android.permission.INTERNET' in your applications manifest file");
+        }
+
         return result == PackageManager.PERMISSION_GRANTED;
     }
     
@@ -606,7 +610,7 @@ public abstract class ServerRequest {
     }
     
     public void reportTrackingDisabledError() {
-        PrefHelper.Debug("BranchSDK", "Requested operation cannot be completed since tracking is disabled [" + requestPath_ + "]");
+        PrefHelper.Debug("Requested operation cannot be completed since tracking is disabled [" + requestPath_ + "]");
         handleFailure(BranchError.ERR_BRANCH_TRACKING_DISABLED, "");
     }
     

--- a/Branch-SDK/src/io/branch/referral/ServerRequestActionCompleted.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestActionCompleted.java
@@ -3,7 +3,6 @@ package io.branch.referral;
 import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
-import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -51,7 +50,7 @@ class ServerRequestActionCompleted extends ServerRequest {
         }
 
         if (action != null && action.equalsIgnoreCase("purchase")) {
-            Log.e("BranchSDK", "Warning: You are sending a purchase event with our non-dedicated purchase function. Please see function sendCommerceEvent");
+            PrefHelper.Debug("Warning: You are sending a purchase event with our non-dedicated purchase function. Please see function sendCommerceEvent");
         }
     }
 
@@ -98,7 +97,6 @@ class ServerRequestActionCompleted extends ServerRequest {
     @Override
     public boolean handleErrors(Context context) {
         if (!super.doesAppHasInternetPermission(context)) {
-            Log.i("BranchSDK", "Trouble executing your request. Please add 'android.permission.INTERNET' in your applications manifest file");
             return true;
         }
         return false;

--- a/Branch-SDK/src/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestInitSession.java
@@ -51,7 +51,7 @@ abstract class ServerRequestInitSession extends ServerRequest {
         }
         post.put(Defines.Jsonkey.FaceBookAppLinkChecked.getKey(), prefHelper_.getIsAppLinkTriggeredInit());
         post.put(Defines.Jsonkey.IsReferrable.getKey(), prefHelper_.getIsReferrable());
-        post.put(Defines.Jsonkey.Debug.getKey(), prefHelper_.getExternDebug());
+        post.put(Defines.Jsonkey.Debug.getKey(), BranchUtil.isDebugEnabled());
 
         updateInstallStateAndTimestamps(post);
         updateEnvironment(context_, post);

--- a/Branch-SDK/src/io/branch/referral/ServerRequestLogout.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestLogout.java
@@ -2,7 +2,6 @@ package io.branch.referral;
 
 import android.app.Application;
 import android.content.Context;
-import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -76,7 +75,6 @@ class ServerRequestLogout extends ServerRequest {
     @Override
     public boolean handleErrors(Context context) {
         if (!super.doesAppHasInternetPermission(context)) {
-            Log.i("BranchSDK", "Trouble executing your request. Please add 'android.permission.INTERNET' in your applications manifest file");
             if (callback_ != null) {
                 callback_.onLogoutFinished(false, new BranchError("Logout failed", BranchError.ERR_NO_INTERNET_PERMISSION));
             }

--- a/Branch-SDK/src/io/branch/referral/ServerRequestPing.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestPing.java
@@ -2,7 +2,6 @@ package io.branch.referral;
 
 import android.app.Application;
 import android.content.Context;
-import android.util.Log;
 
 /**
  * * <p>
@@ -23,7 +22,6 @@ public class ServerRequestPing extends ServerRequest {
     @Override
     public boolean handleErrors(Context context) {
         if (!super.doesAppHasInternetPermission(context)) {
-            PrefHelper.Debug("BranchSDK", "Trouble executing your request. Please add 'android.permission.INTERNET' in your applications manifest file");
             return true;
         }
         return false;

--- a/Branch-SDK/src/io/branch/referral/ServerRequestQueue.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestQueue.java
@@ -90,7 +90,7 @@ class ServerRequestQueue {
                     editor.putString(PREF_KEY, jsonArr.toString()).commit();
                 } catch (Exception ex) {
                     String msg = ex.getMessage();
-                    PrefHelper.Debug("BranchSDK", "Failed to persit queue" + (msg == null ? "" : msg));
+                    PrefHelper.Debug("Failed to persit queue" + (msg == null ? "" : msg));
                 }
             }
         }).start();

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRActionCompleted.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRActionCompleted.java
@@ -3,7 +3,6 @@ package io.branch.referral;
 import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
-import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -99,7 +98,6 @@ class ServerRequestRActionCompleted extends ServerRequest {
     @Override
     public boolean handleErrors(Context context) {
         if (!super.doesAppHasInternetPermission(context)) {
-            Log.i("BranchSDK", "Trouble executing your request. Please add 'android.permission.INTERNET' in your applications manifest file");
             return true;
         }
         return false;

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRedeemRewards.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRedeemRewards.java
@@ -2,7 +2,6 @@ package io.branch.referral;
 
 import android.app.Application;
 import android.content.Context;
-import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -39,7 +38,7 @@ class ServerRequestRedeemRewards extends ServerRequest {
         actualNumOfCreditsToRedeem_ = numOfCreditsToRedeem;
         if (numOfCreditsToRedeem > availableCredits) {
             actualNumOfCreditsToRedeem_ = availableCredits;
-            Log.i("BranchSDK", "Branch Warning: You're trying to redeem more credits than are available. Have you updated loaded rewards");
+            PrefHelper.Debug("Warning: You're trying to redeem more credits than are available. Have you updated loaded rewards");
         }
         if (actualNumOfCreditsToRedeem_ > 0) {
             JSONObject post = new JSONObject();

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterClose.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterClose.java
@@ -2,7 +2,6 @@ package io.branch.referral;
 
 import android.app.Application;
 import android.content.Context;
-import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -53,7 +52,6 @@ class ServerRequestRegisterClose extends ServerRequest {
     @Override
     public boolean handleErrors(Context context) {
         if (!super.doesAppHasInternetPermission(context)) {
-            Log.i("BranchSDK", "Trouble executing your request. Please add 'android.permission.INTERNET' in your applications manifest file");
             return true;
         }
         return false;

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterView.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterView.java
@@ -96,7 +96,7 @@ class ServerRequestRegisterView extends ServerRequest {
         if (DeviceInfo.getInstance() != null) {
             uniqueId = DeviceInfo.getInstance().getHardwareID();
         } else {
-            uniqueId = sysObserver.getUniqueID(prefHelper_.getExternDebug());
+            uniqueId = sysObserver.getUniqueID(BranchUtil.isDebugEnabled());
         }
         if (!uniqueId.equals(SystemObserver.BLANK) && sysObserver.hasRealHardwareId()) {
             contentObject.put(Defines.Jsonkey.HardwareID.getKey(), uniqueId);

--- a/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
+++ b/Branch-SDK/src/io/branch/referral/ShareLinkManager.java
@@ -12,7 +12,6 @@ import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -85,7 +84,7 @@ class ShareLinkManager {
             if (callback_ != null) {
                 callback_.onLinkShareResponse(null, null, new BranchError("Trouble sharing link", BranchError.ERR_BRANCH_NO_SHARE_OPTION));
             } else {
-                Log.i("BranchSDK", "Unable create share options. Couldn't find applications on device to share the link.");
+                PrefHelper.Debug("Unable create share options. Couldn't find applications on device to share the link.");
             }
         }
         return shareDlg_;
@@ -291,7 +290,7 @@ class ShareLinkManager {
                         if (callback_ != null) {
                             callback_.onLinkShareResponse(url, channelName, error);
                         } else {
-                            Log.i("BranchSDK", "Unable to share link " + error.getMessage());
+                            PrefHelper.Debug("Unable to share link " + error.getMessage());
                         }
                         if (error.getErrorCode() == BranchError.ERR_BRANCH_NO_CONNECTIVITY
                                 || error.getErrorCode() == BranchError.ERR_BRANCH_TRACKING_DISABLED) {
@@ -310,7 +309,7 @@ class ShareLinkManager {
         if (callback_ != null) {
             callback_.onLinkShareResponse(url, channelName, null);
         } else {
-            Log.i("BranchSDK", "Shared link with " + channelName);
+            PrefHelper.Debug("Shared link with " + channelName);
         }
         if (selectedResolveInfo instanceof CopyLinkItem) {
             addLinkToClipBoard(url, builder_.getShareMsg());

--- a/Branch-SDK/src/io/branch/referral/SystemObserver.java
+++ b/Branch-SDK/src/io/branch/referral/SystemObserver.java
@@ -77,7 +77,7 @@ class SystemObserver {
     String getUniqueID(boolean debug) {
         if (context_ != null) {
             String androidID = null;
-            if (!debug && !Branch.isSimulatingInstalls_) {
+            if (!debug && !Branch.isSimulatingInstalls()) {
                 androidID = Secure.getString(context_.getContentResolver(), Secure.ANDROID_ID);
             }
             if (androidID == null) {

--- a/Branch-SDK/src/io/branch/referral/network/BranchRemoteInterface.java
+++ b/Branch-SDK/src/io/branch/referral/network/BranchRemoteInterface.java
@@ -93,7 +93,7 @@ public abstract class BranchRemoteInterface {
         }
 
         long reqStartTime = System.currentTimeMillis();
-        PrefHelper.Debug("BranchSDK", "getting " + modifiedUrl);
+        PrefHelper.Debug("getting " + modifiedUrl);
 
         try {
             BranchResponse response = doRestfulGet(modifiedUrl);
@@ -129,8 +129,8 @@ public abstract class BranchRemoteInterface {
         if (!addCommonParams(body, branchKey)) {
             return new ServerResponse(tag, BranchError.ERR_BRANCH_KEY_INVALID);
         }
-        PrefHelper.Debug("BranchSDK", "posting to " + url);
-        PrefHelper.Debug("BranchSDK", "Post value = " + body.toString());
+        PrefHelper.Debug("posting to " + url);
+        PrefHelper.Debug("Post value = " + body.toString());
 
         try {
             BranchResponse response = doRestfulPost(url, body);
@@ -180,7 +180,7 @@ public abstract class BranchRemoteInterface {
      */
     private ServerResponse processEntityForJSON(String responseString, int statusCode, String tag) {
         ServerResponse result = new ServerResponse(tag, statusCode);
-        PrefHelper.Debug("BranchSDK", "returned " + responseString);
+        PrefHelper.Debug("returned " + responseString);
 
         if (responseString != null) {
             try {
@@ -191,7 +191,7 @@ public abstract class BranchRemoteInterface {
                     JSONArray jsonArray = new JSONArray(responseString);
                     result.setPost(jsonArray);
                 } catch (JSONException ex2) {
-                    PrefHelper.Debug(getClass().getSimpleName(), "JSON exception: " + ex2.getMessage());
+                    PrefHelper.Debug("JSON exception: " + ex2.getMessage());
                 }
             }
         }

--- a/Branch-SDK/src/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
+++ b/Branch-SDK/src/io/branch/referral/network/BranchRemoteInterfaceUrlConnection.java
@@ -3,7 +3,6 @@ package io.branch.referral.network;
 import android.content.Context;
 import android.net.TrafficStats;
 import android.os.NetworkOnMainThreadException;
-import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -32,7 +31,7 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
     private static final int DEFAULT_TIMEOUT = 3000;
     private static final int THREAD_TAG_POST= 102;
 
-    PrefHelper prefHelper;
+    private PrefHelper prefHelper;
 
     BranchRemoteInterfaceUrlConnection(Context context) {
         prefHelper = PrefHelper.getInstance(context);
@@ -83,12 +82,12 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
                     }
                 } catch (FileNotFoundException ex) {
                     // In case of Resource conflict getInputStream will throw FileNotFoundException. Handle it here in order to send the right status code
-                    PrefHelper.Debug("BranchSDK", "A resource conflict occurred with this request " + url);
+                    PrefHelper.Debug("A resource conflict occurred with this request " + url);
                     return new BranchResponse(null, responseCode);
                 }
             }
         } catch (SocketException ex) {
-            PrefHelper.Debug(getClass().getSimpleName(), "Http connect exception: " + ex.getMessage());
+            PrefHelper.Debug("Http connect exception: " + ex.getMessage());
             throw new BranchRemoteException(BranchError.ERR_BRANCH_NO_CONNECTIVITY);
 
         } catch (SocketTimeoutException ex) {
@@ -105,7 +104,7 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
                 throw new BranchRemoteException(BranchError.ERR_BRANCH_REQ_TIMED_OUT);
             }
         } catch (IOException ex) {
-            PrefHelper.Debug(getClass().getSimpleName(), "Branch connect exception: " + ex.getMessage());
+            PrefHelper.Debug("Branch connect exception: " + ex.getMessage());
             throw new BranchRemoteException(BranchError.ERR_BRANCH_NO_CONNECTIVITY);
         } finally {
             if (connection != null) {
@@ -168,7 +167,7 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
                     return new BranchResponse(getResponseString(inputStream), responseCode);
                 } catch (FileNotFoundException ex) {
                     // In case of Resource conflict getInputStream will throw FileNotFoundException. Handle it here in order to send the right status code
-                    PrefHelper.Debug("BranchSDK", "A resource conflict occurred with this request " + url);
+                    PrefHelper.Debug("A resource conflict occurred with this request " + url);
                     return new BranchResponse(null, responseCode);
                 } finally {
                     try {
@@ -196,13 +195,13 @@ public class BranchRemoteInterfaceUrlConnection extends BranchRemoteInterface {
                 throw new BranchRemoteException(BranchError.ERR_BRANCH_REQ_TIMED_OUT);
             }
         } catch (IOException ex) {
-            PrefHelper.Debug(getClass().getSimpleName(), "Http connect exception: " + ex.getMessage());
+            PrefHelper.Debug("Http connect exception: " + ex.getMessage());
             throw new BranchRemoteException(BranchError.ERR_BRANCH_NO_CONNECTIVITY);
         } catch (Exception ex) {
-            PrefHelper.Debug(getClass().getSimpleName(), "Exception: " + ex.getMessage());
+            PrefHelper.Debug("Exception: " + ex.getMessage());
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB) {
                 if (ex instanceof NetworkOnMainThreadException)
-                    Log.i("BranchSDK", "Branch Error: Don't call our synchronous methods on the main thread!!!");
+                    PrefHelper.Debug("Branch Error: Don't call our synchronous methods on the main thread!!!");
             }
             return new BranchResponse(null, 500);
         } finally {

--- a/Branch-SDK/src/io/branch/referral/validators/DeepLinkRoutingValidator.java
+++ b/Branch-SDK/src/io/branch/referral/validators/DeepLinkRoutingValidator.java
@@ -3,14 +3,12 @@ package io.branch.referral.validators;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Handler;
 import android.text.TextUtils;
-import android.util.Log;
 
 import org.json.JSONObject;
 
@@ -18,6 +16,7 @@ import java.lang.ref.WeakReference;
 
 import io.branch.referral.Branch;
 import io.branch.referral.Defines;
+import io.branch.referral.PrefHelper;
 
 public class DeepLinkRoutingValidator {
     private static final String VALIDATE_SDK_LINK_PARAM_KEY = "bnc_validate";
@@ -116,7 +115,7 @@ public class DeepLinkRoutingValidator {
             link = blob.getString("~" + Defines.Jsonkey.ReferringLink.getKey());
             link = link.split("\\?")[0];
         } catch (Exception e) {
-            Log.e("BRANCH SDK", "Failed to get referring link");
+            PrefHelper.Debug("Failed to get referring link");
         }
         link += "?" + VALIDATE_LINK_PARAM_KEY + "=true";
         if (!TextUtils.isEmpty(result)) {

--- a/Branch-SDK/src/io/branch/referral/validators/IntegrationValidator.java
+++ b/Branch-SDK/src/io/branch/referral/validators/IntegrationValidator.java
@@ -12,7 +12,6 @@ import java.util.Iterator;
 
 import io.branch.referral.Branch;
 import io.branch.referral.BranchUtil;
-import io.branch.referral.PrefHelper;
 
 /**
  * Created by sojanpr on 9/15/17.
@@ -48,7 +47,7 @@ public class IntegrationValidator implements ServerRequestGetAppConfig.IGetAppCo
 
         // 2. Verify Branch Keys
         logValidationProgress("2. Checking Branch keys");
-        if (TextUtils.isEmpty(PrefHelper.getInstance(context).readBranchKey(!BranchUtil.isTestModeEnabled(context)))) {
+        if (TextUtils.isEmpty(BranchUtil.readBranchKey(context))) {
             logIntegrationError("Unable to read Branch keys from your application. Did you forget to add Branch keys in your application?.",
                     "https://docs.branch.io/pages/apps/android/#configure-app");
             return;
@@ -195,11 +194,11 @@ public class IntegrationValidator implements ServerRequestGetAppConfig.IGetAppCo
         if (integrationModel.deeplinkUriScheme != null) {
             for (Iterator<String> it = integrationModel.deeplinkUriScheme.keys(); it.hasNext(); ) {
                 String key = it.next();
-                if (uriHost.equals(key)) {
+                if (uriHost != null && uriHost.equals(key)) {
                     JSONArray hosts = integrationModel.deeplinkUriScheme.optJSONArray(key);
                     if (hosts != null && hosts.length() > 0) {
                         for (int i = 0; i < hosts.length(); ++i) {
-                            if (uriPath.equals(hosts.optString(i))) {
+                            if (uriPath != null && uriPath.equals(hosts.optString(i))) {
                                 foundMatchingUri = true;
                                 break;
                             }


### PR DESCRIPTION
## Reference
SDK-157 -- setDebug() no longer works as expected.

## Description
Internal testing found that calling setDebug() before initSession() can be overridden by the setting of test mode in the manifest.

As part of this ticket, I unwound how the interactions between debug mode and test mode, and refactored quite a lot of the different ways that debugging works within the SDK.

## Testing Instructions
* Sample app should continue to function.
* Unit tests pass

### Detailed Testing Instructions
It turns out that the original issue was around the distinction between `setDebug()` and `enableLogging()`, and the interactions that happen between them.

**To demonstrate the problem**
1. add `setDebug()` in the TestBed app in `onStart()`.
2. change the manifest test flag to "false"

* OLD behavior:  You will not see logs until after you rotate the screen or background/foreground the app.
* NEW behavior:  You will see logs appropriately.

## Risk Assessment [`MEDIUM`]
I touched rather more code that I expected to.  There is not only a number of different ways to enable debugging and test mode, the keys are tied to how debugging is enabled as well.

- [X] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [x] JIRA Ticket is referenced in PR title
- Correctness & Style
    - [x] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [x] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)
