### PR TITLE
SDK-230 -- Unwind SystemObserver

### DIFF
--- a/Branch-SDK/androidTest/io/branch/referral/DeviceInfoTest.java
+++ b/Branch-SDK/androidTest/io/branch/referral/DeviceInfoTest.java
@@ -1,0 +1,85 @@
+package io.branch.referral;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class DeviceInfoTest extends BranchTest {
+
+    @Test
+    public void testDeviceInfoExists() {
+        Assert.assertNotNull(Branch.getInstance(getTestContext()));
+        Assert.assertNotNull(DeviceInfo.getInstance());
+    }
+
+    @Test
+    public void testHardwareIdDebug() {
+        // NOTE that this is essentially the same test as using Simulated Installs
+        Assert.assertNotNull(Branch.getInstance(getTestContext()));
+        Assert.assertNotNull(DeviceInfo.getInstance());
+
+        // Start with debug mode off and get a hardwareId
+        SystemObserver.UniqueId uniqueId1 = DeviceInfo.getInstance().getHardwareID();
+
+        // Enable debug mode
+        Branch.enableDebugMode();
+        SystemObserver.UniqueId uniqueDebugId1 = DeviceInfo.getInstance().getHardwareID();
+        SystemObserver.UniqueId uniqueDebugId2 = DeviceInfo.getInstance().getHardwareID();
+
+        // Per design, two requests for debug IDs must be different.
+        Assert.assertNotEquals(uniqueDebugId1, uniqueDebugId2);
+
+        // A "Real" hardware Id should always be identical, even after switching debug on and off.
+        Branch.disableDebugMode();
+        SystemObserver.UniqueId uniqueId2 = DeviceInfo.getInstance().getHardwareID();
+        Assert.assertEquals(uniqueId1, uniqueId2);
+    }
+
+    @Test
+    public void testHardwareIdSimulatedInstall() {
+        // NOTE that this is essentially the same test as using Debug
+        Assert.assertNotNull(Branch.getInstance(getTestContext()));
+        Assert.assertNotNull(DeviceInfo.getInstance());
+
+        // Start with simulation mode off and get a hardwareId
+        SystemObserver.UniqueId uniqueId1 = DeviceInfo.getInstance().getHardwareID();
+
+        // Enable simulated installs
+        Branch.enableSimulateInstalls();
+        SystemObserver.UniqueId uniqueSimulatedId1 = DeviceInfo.getInstance().getHardwareID();
+        SystemObserver.UniqueId uniqueSimulatedId2 = DeviceInfo.getInstance().getHardwareID();
+
+        // Per design, two requests for simulated IDs must be different.
+        Assert.assertNotEquals(uniqueSimulatedId1, uniqueSimulatedId2);
+
+        // A "Real" hardware Id should always be identical, even after switching simulation mode on and off.
+        Branch.disableSimulateInstalls();
+        SystemObserver.UniqueId uniqueId2 = DeviceInfo.getInstance().getHardwareID();
+        Assert.assertEquals(uniqueId1, uniqueId2);
+    }
+
+    @Test
+    public void testGAIDFetch() {
+        Assert.assertNotNull(Branch.getInstance(getTestContext()));
+        Assert.assertNotNull(DeviceInfo.getInstance());
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        DeviceInfo.getInstance().getSystemObserver().prefetchGAdsParams(getTestContext(), new SystemObserver.GAdsParamsFetchEvents() {
+            @Override
+            public void onGAdsFetchFinished() {
+                latch.countDown();
+            }
+        });
+
+        try {
+            latch.await(5000, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Assert.fail();
+        }
+
+        Assert.assertFalse(DeviceInfo.isNullOrEmptyOrBlank(DeviceInfo.getInstance().getSystemObserver().getGAID()));
+        Assert.assertNotEquals(0, DeviceInfo.getInstance().getSystemObserver().getLATVal());
+    }
+}

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -3251,15 +3251,17 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     }
 
     /**
-     * @deprecated use {@link Branch#enableDebugMode()}
+     * Enable Logging, independent of Debug Mode.
      */
     public static void enableLogging() {
+        PrefHelper.enableLogging(true);
     }
 
     /**
-     * @deprecated use {@link Branch#disableDebugMode()}
+     * Disable Logging, independent of Debug Mode.
      */
     public static void disableLogging() {
+        PrefHelper.enableLogging(false);
     }
 
     public static void enableForcedSession() {

--- a/Branch-SDK/src/io/branch/referral/BranchStrongMatchHelper.java
+++ b/Branch-SDK/src/io/branch/referral/BranchStrongMatchHelper.java
@@ -36,7 +36,6 @@ class BranchStrongMatchHelper {
     private boolean isStrongMatchUrlLaunched = false;
 
     private Class<?> CustomTabsClientClass;
-    // private Class<?> CustomServiceTabConnectionClass;
     private Class<?> CustomTabsCallbackClass;
     private Class<?> CustomTabsSessionClass;
     private Class<?> ICustomTabsServiceClass;
@@ -44,7 +43,6 @@ class BranchStrongMatchHelper {
     {
         try {
             CustomTabsClientClass = Class.forName("android.support.customtabs.CustomTabsClient");
-            // CustomServiceTabConnectionClass = Class.forName("android.support.customtabs.CustomTabsServiceConnection");
             CustomTabsCallbackClass = Class.forName("android.support.customtabs.CustomTabsCallback");
             CustomTabsSessionClass = Class.forName("android.support.customtabs.CustomTabsSession");
             ICustomTabsServiceClass = Class.forName("android.support.customtabs.ICustomTabsService");
@@ -88,7 +86,6 @@ class BranchStrongMatchHelper {
                             }
                         }, STRONG_MATCH_CHECK_TIME_OUT);
 
-                        //Method bindCustomTabsServiceMethod = CustomTabsClientClass.getMethod("bindCustomTabsService", Context.class, String.class, CustomServiceTabConnectionClass);
                         final Method warmupMethod = CustomTabsClientClass.getMethod("warmup", long.class);
                         final Method newSessionMethod = CustomTabsClientClass.getMethod("newSession", CustomTabsCallbackClass);
                         final Method mayLaunchUrlMethod = CustomTabsSessionClass.getMethod("mayLaunchUrl", Uri.class, Bundle.class, List.class);

--- a/Branch-SDK/src/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/io/branch/referral/DeviceInfo.java
@@ -16,72 +16,19 @@ import org.json.JSONObject;
  * </p>
  */
 class DeviceInfo {
-    /**
-     * Immutable device hardware id
-     */
-    private final String hardwareID_;
-    /**
-     * Status for test vs real hardware ID
-     */
-    private final boolean isHardwareIDReal_;
-    /*
-     * Device manufacturer name
-     */
-    private final String brandName_;
-    /**
-     * Device model name
-     */
-    private final String modelName_;
-    /**
-     * Screen pixel density
-     */
-    private final int screenDensity_;
-    /**
-     * Height of the screen in pixels
-     */
-    private final int screenHeight_;
-    /**
-     * Width of the screen in pixels
-     */
-    private final int screenWidth_;
-    /**
-     * Status for connected to wifi or not
-     */
-    private final boolean isWifiConnected_;
-    /**
-     * Local IP address for the device
-     */
-    private final String localIpAddr_;
-    /**
-     * Device os name
-     */
-    private final String osName_;
-    /**
-     * Device OS version
-     */
-    private final int osVersion_;
-    /**
-     * Device type
-     */
-    private final String UIMode_;
-
-    private final String packageName_;
-    private final String appVersion_;
-    private final String countryCode_;
-    private final String languageCode_;
+    private final SystemObserver systemObserver_;
+    private final Context context_;
 
     private static DeviceInfo thisInstance_ = null;
 
-
     /**
-     * Get the singleton instance for deviceInfo class
+     * Initialize the singleton instance for deviceInfo class
      *
-     * @param sysObserver {@link SystemObserver} instance to get device info
      * @return {@link DeviceInfo} global instance
      */
-    public static DeviceInfo getInstance(boolean isExternalDebug, SystemObserver sysObserver, boolean disableAndroidIDFetch) {
+    static DeviceInfo initialize(Context context) {
         if (thisInstance_ == null) {
-            thisInstance_ = new DeviceInfo(isExternalDebug, sysObserver, disableAndroidIDFetch);
+            thisInstance_ = new DeviceInfo(context);
         }
         return thisInstance_;
     }
@@ -91,38 +38,18 @@ class DeviceInfo {
      *
      * @return {@link DeviceInfo} instance if already initialised or null
      */
-    public static DeviceInfo getInstance() {
+    static DeviceInfo getInstance() {
         return thisInstance_;
     }
 
+    // Package Private
+    static void shutDown() {
+        thisInstance_ = null;
+    }
 
-    private DeviceInfo(boolean isExternalDebug, SystemObserver sysObserver, boolean disableAndroidIDFetch) {
-        if (disableAndroidIDFetch) {
-            hardwareID_ = sysObserver.getUniqueID(true);
-        } else {
-            hardwareID_ = sysObserver.getUniqueID(isExternalDebug);
-        }
-        isHardwareIDReal_ = sysObserver.hasRealHardwareId();
-        brandName_ = sysObserver.getPhoneBrand();
-        modelName_ = sysObserver.getPhoneModel();
-
-        DisplayMetrics dMetrics = sysObserver.getScreenDisplay();
-        screenDensity_ = dMetrics.densityDpi;
-        screenHeight_ = dMetrics.heightPixels;
-        screenWidth_ = dMetrics.widthPixels;
-
-        isWifiConnected_ = sysObserver.getWifiConnected();
-        localIpAddr_ = SystemObserver.getLocalIPAddress();
-
-        osName_ = sysObserver.getOS();
-        osVersion_ = sysObserver.getOSVersion();
-
-        packageName_ = sysObserver.getPackageName();
-        appVersion_ = sysObserver.getAppVersion();
-        countryCode_ = sysObserver.getISO2CountryCode();
-        languageCode_ = sysObserver.getISO2LanguageCode();
-
-        UIMode_ = sysObserver.getUIMode();
+    private DeviceInfo(Context context) {
+        context_ = context;
+        systemObserver_ = new SystemObserverInstance();
     }
 
     /**
@@ -130,37 +57,52 @@ class DeviceInfo {
      *
      * @param requestObj JSON object for Branch server request
      */
-    public void updateRequestWithDeviceParams(JSONObject requestObj) {
+    public void updateRequestWithV1Params(JSONObject requestObj) {
         try {
-            if (!hardwareID_.equals(SystemObserver.BLANK)) {
-                requestObj.put(Defines.Jsonkey.HardwareID.getKey(), hardwareID_);
-                requestObj.put(Defines.Jsonkey.IsHardwareIDReal.getKey(), isHardwareIDReal_);
-            }
-            if (!brandName_.equals(SystemObserver.BLANK)) {
-                requestObj.put(Defines.Jsonkey.Brand.getKey(), brandName_);
-            }
-            if (!modelName_.equals(SystemObserver.BLANK)) {
-                requestObj.put(Defines.Jsonkey.Model.getKey(), modelName_);
+            SystemObserver.UniqueId hardwareID = getHardwareID();
+            if (!isNullOrEmptyOrBlank(hardwareID.getId())) {
+                requestObj.put(Defines.Jsonkey.HardwareID.getKey(), hardwareID.getId());
+                requestObj.put(Defines.Jsonkey.IsHardwareIDReal.getKey(), hardwareID.isReal());
             }
 
-            requestObj.put(Defines.Jsonkey.ScreenDpi.getKey(), screenDensity_);
-            requestObj.put(Defines.Jsonkey.ScreenHeight.getKey(), screenHeight_);
-            requestObj.put(Defines.Jsonkey.ScreenWidth.getKey(), screenWidth_);
-            requestObj.put(Defines.Jsonkey.WiFi.getKey(), isWifiConnected_);
-            requestObj.put(Defines.Jsonkey.UIMode.getKey(), UIMode_);
+            String brandName = SystemObserver.getPhoneBrand();
+            if (!isNullOrEmptyOrBlank(brandName)) {
+                requestObj.put(Defines.Jsonkey.Brand.getKey(), brandName);
+            }
 
-            if (!osName_.equals(SystemObserver.BLANK)) {
-                requestObj.put(Defines.Jsonkey.OS.getKey(), osName_);
+            String modelName = SystemObserver.getPhoneModel();
+            if (!isNullOrEmptyOrBlank(modelName)) {
+                requestObj.put(Defines.Jsonkey.Model.getKey(), modelName);
             }
-            requestObj.put(Defines.Jsonkey.OSVersion.getKey(), osVersion_);
-            if (!TextUtils.isEmpty(countryCode_)) {
-                requestObj.put(Defines.Jsonkey.Country.getKey(), countryCode_);
+
+            DisplayMetrics displayMetrics = SystemObserver.getScreenDisplay(context_);
+            requestObj.put(Defines.Jsonkey.ScreenDpi.getKey(), displayMetrics.densityDpi);
+            requestObj.put(Defines.Jsonkey.ScreenHeight.getKey(), displayMetrics.heightPixels);
+            requestObj.put(Defines.Jsonkey.ScreenWidth.getKey(), displayMetrics.widthPixels);
+
+            requestObj.put(Defines.Jsonkey.WiFi.getKey(), SystemObserver.getWifiConnected(context_));
+            requestObj.put(Defines.Jsonkey.UIMode.getKey(), SystemObserver.getUIMode(context_));
+
+            String osName = SystemObserver.getOS();
+            if (!isNullOrEmptyOrBlank(osName)) {
+                requestObj.put(Defines.Jsonkey.OS.getKey(), osName);
             }
-            if (!TextUtils.isEmpty(languageCode_)) {
-                requestObj.put(Defines.Jsonkey.Language.getKey(), languageCode_);
+
+            requestObj.put(Defines.Jsonkey.OSVersion.getKey(), SystemObserver.getOSVersion());
+
+            String countryCode = SystemObserver.getISO2CountryCode();
+            if (!TextUtils.isEmpty(countryCode)) {
+                requestObj.put(Defines.Jsonkey.Country.getKey(), countryCode);
             }
-            if ((!TextUtils.isEmpty(localIpAddr_))) {
-                requestObj.put(Defines.Jsonkey.LocalIP.getKey(), localIpAddr_);
+
+            String languageCode = SystemObserver.getISO2LanguageCode();
+            if (!TextUtils.isEmpty(languageCode)) {
+                requestObj.put(Defines.Jsonkey.Language.getKey(), languageCode);
+            }
+
+            String localIpAddr = SystemObserver.getLocalIPAddress();
+            if ((!TextUtils.isEmpty(localIpAddr))) {
+                requestObj.put(Defines.Jsonkey.LocalIP.getKey(), localIpAddr);
             }
 
         } catch (JSONException ignore) {
@@ -173,45 +115,63 @@ class DeviceInfo {
      *
      * @param requestObj JSON object for Branch server request
      */
-    public void updateRequestWithUserData(Context context, PrefHelper prefHelper, JSONObject requestObj) {
+    public void updateRequestWithV2Params(Context context, PrefHelper prefHelper, JSONObject requestObj) {
         try {
-            if (!hardwareID_.equals(SystemObserver.BLANK) && isHardwareIDReal_) {
-                requestObj.put(Defines.Jsonkey.AndroidID.getKey(), hardwareID_);
+            SystemObserver.UniqueId hardwareID = getHardwareID();
+            if (!isNullOrEmptyOrBlank(hardwareID.getId()) && hardwareID.isReal()) {
+                requestObj.put(Defines.Jsonkey.AndroidID.getKey(), hardwareID.getId());
             } else {
                 requestObj.put(Defines.Jsonkey.UnidentifiedDevice.getKey(), true);
             }
 
-            if (!brandName_.equals(SystemObserver.BLANK)) {
-                requestObj.put(Defines.Jsonkey.Brand.getKey(), brandName_);
+            String brandName = SystemObserver.getPhoneBrand();
+            if (!isNullOrEmptyOrBlank(brandName)) {
+                requestObj.put(Defines.Jsonkey.Brand.getKey(), brandName);
             }
-            if (!modelName_.equals(SystemObserver.BLANK)) {
-                requestObj.put(Defines.Jsonkey.Model.getKey(), modelName_);
-            }
-            requestObj.put(Defines.Jsonkey.ScreenDpi.getKey(), screenDensity_);
-            requestObj.put(Defines.Jsonkey.ScreenHeight.getKey(), screenHeight_);
-            requestObj.put(Defines.Jsonkey.ScreenWidth.getKey(), screenWidth_);
 
-            if (!osName_.equals(SystemObserver.BLANK)) {
-                requestObj.put(Defines.Jsonkey.OS.getKey(), osName_);
+            String modelName = SystemObserver.getPhoneModel();
+            if (!isNullOrEmptyOrBlank(modelName)) {
+                requestObj.put(Defines.Jsonkey.Model.getKey(), modelName);
             }
-            requestObj.put(Defines.Jsonkey.OSVersion.getKey(), osVersion_);
-            if (!TextUtils.isEmpty(countryCode_)) {
-                requestObj.put(Defines.Jsonkey.Country.getKey(), countryCode_);
+
+            DisplayMetrics displayMetrics = SystemObserver.getScreenDisplay(context_);
+            requestObj.put(Defines.Jsonkey.ScreenDpi.getKey(), displayMetrics.densityDpi);
+            requestObj.put(Defines.Jsonkey.ScreenHeight.getKey(), displayMetrics.heightPixels);
+            requestObj.put(Defines.Jsonkey.ScreenWidth.getKey(), displayMetrics.widthPixels);
+
+            String osName = SystemObserver.getOS();
+            if (!isNullOrEmptyOrBlank(osName)) {
+                requestObj.put(Defines.Jsonkey.OS.getKey(), osName);
             }
-            if (!TextUtils.isEmpty(languageCode_)) {
-                requestObj.put(Defines.Jsonkey.Language.getKey(), languageCode_);
+
+            requestObj.put(Defines.Jsonkey.OSVersion.getKey(), SystemObserver.getOSVersion());
+
+            String countryCode = SystemObserver.getISO2CountryCode();
+            if (!TextUtils.isEmpty(countryCode)) {
+                requestObj.put(Defines.Jsonkey.Country.getKey(), countryCode);
             }
-            if ((!TextUtils.isEmpty(localIpAddr_))) {
-                requestObj.put(Defines.Jsonkey.LocalIP.getKey(), localIpAddr_);
+
+            String languageCode = SystemObserver.getISO2LanguageCode();
+            if (!TextUtils.isEmpty(languageCode)) {
+                requestObj.put(Defines.Jsonkey.Language.getKey(), languageCode);
             }
-            if (prefHelper != null && !prefHelper.getDeviceFingerPrintID().equals(PrefHelper.NO_STRING_VALUE)) {
-                requestObj.put(Defines.Jsonkey.DeviceFingerprintID.getKey(), prefHelper.getDeviceFingerPrintID());
+
+            String localIpAddr = SystemObserver.getLocalIPAddress();
+            if ((!TextUtils.isEmpty(localIpAddr))) {
+                requestObj.put(Defines.Jsonkey.LocalIP.getKey(), localIpAddr);
             }
-            String devId = prefHelper.getIdentity();
-            if (devId != null && !devId.equals(PrefHelper.NO_STRING_VALUE)) {
-                requestObj.put(Defines.Jsonkey.DeveloperIdentity.getKey(), prefHelper.getIdentity());
+
+            if (prefHelper != null) {
+                if (!isNullOrEmptyOrBlank(prefHelper.getDeviceFingerPrintID())) {
+                    requestObj.put(Defines.Jsonkey.DeviceFingerprintID.getKey(), prefHelper.getDeviceFingerPrintID());
+                }
+                String devId = prefHelper.getIdentity();
+                if (!isNullOrEmptyOrBlank(devId)) {
+                    requestObj.put(Defines.Jsonkey.DeveloperIdentity.getKey(), devId);
+                }
             }
-            requestObj.put(Defines.Jsonkey.AppVersion.getKey(), DeviceInfo.getInstance().getAppVersion());
+
+            requestObj.put(Defines.Jsonkey.AppVersion.getKey(), getAppVersion());
             requestObj.put(Defines.Jsonkey.SDK.getKey(), "android");
             requestObj.put(Defines.Jsonkey.SdkVersion.getKey(), BuildConfig.VERSION_NAME);
             requestObj.put(Defines.Jsonkey.UserAgent.getKey(), getDefaultBrowserAgent(context));
@@ -225,7 +185,7 @@ class DeviceInfo {
      * @return {@link String} with package name value
      */
     public String getPackageName() {
-        return packageName_;
+        return systemObserver_.getPackageName(context_);
     }
 
     /**
@@ -234,19 +194,28 @@ class DeviceInfo {
      * @return {@link String} with app version value
      */
     public String getAppVersion() {
-        return appVersion_;
+        return systemObserver_.getAppVersion(context_);
     }
 
-    public boolean isHardwareIDReal() {
-        return isHardwareIDReal_;
+    /**
+     * @return true if a Debug HardwareId is needed.
+     * Note that if either Debug is enabled or Fetch has been disabled, then requests for a Hardware Id will return a "fake" ID.
+     */
+    static public boolean isDebugHardwareIdNeeded() {
+        boolean isDebugHardwareIdNeeded = Branch.isDeviceIDFetchDisabled() || BranchUtil.isDebugEnabled();
+        return isDebugHardwareIdNeeded;
     }
 
-    public String getHardwareID() {
-        return hardwareID_.equals(SystemObserver.BLANK) ? null : hardwareID_;
+    /**
+     * @return the device Hardware ID.
+     * Note that if either Debug is enabled or Fetch has been disabled, then return a "fake" ID.
+     */
+    public SystemObserver.UniqueId getHardwareID() {
+        return getSystemObserver().getUniqueID(context_, isDebugHardwareIdNeeded());
     }
 
     public String getOsName() {
-        return osName_;
+        return systemObserver_.getOS();
     }
 
     // PRS : User agent is checked only from api-17
@@ -262,5 +231,26 @@ class DeviceInfo {
         }
         return userAgent;
     }
+
+    /**
+     * Concrete SystemObserver implementation
+     */
+    private class SystemObserverInstance extends SystemObserver {
+        public SystemObserverInstance() {
+            super();
+        }
+    }
+
+    /**
+     * @return the current SystemObserver instance
+     */
+    SystemObserver getSystemObserver() {
+        return systemObserver_;
+    }
+
+    public static boolean isNullOrEmptyOrBlank(String str) {
+        return TextUtils.isEmpty(str) || str.equals(SystemObserver.BLANK);
+    }
+
 
 }

--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -1150,7 +1150,7 @@ public class PrefHelper {
      * @param message A {@link String} value containing the debug message to record.
      */
     public static void Debug(String message) {
-        if (BranchUtil.isDebugEnabled()) {
+        if (BranchUtil.isDebugEnabled() || enableLogging_) {
             if (!TextUtils.isEmpty(message)) {
                 Log.i("BranchSDK", message);
             }
@@ -1161,5 +1161,11 @@ public class PrefHelper {
         if (!TextUtils.isEmpty(message)) {
             Log.i("BranchSDK", message);
         }
+    }
+
+    private static boolean enableLogging_ = false;
+
+    static void enableLogging(boolean fEnable) {
+        enableLogging_ = fEnable;
     }
 }

--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -170,6 +170,7 @@ public class PrefHelper {
         }
 
         // Reset all of the statics.
+        enableLogging_ = false;
         Branch_Key = null;
         savedAnalyticsData_ = null;
         prefHelper_ = null;

--- a/Branch-SDK/src/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestInitSession.java
@@ -14,7 +14,7 @@ import io.branch.referral.validators.DeepLinkRoutingValidator;
 
 /**
  * <p>
- * Abstract for Session init request. All request which do initilaise session should extend from this.
+ * Abstract for Session init request. All request which do initialize session should extend from this.
  * </p>
  */
 abstract class ServerRequestInitSession extends ServerRequest {
@@ -22,32 +22,30 @@ abstract class ServerRequestInitSession extends ServerRequest {
     static final String ACTION_INSTALL = "install";
     private final Context context_;
     private final ContentDiscoveryManifest contentDiscoveryManifest_;
-    final SystemObserver systemObserver_;
 
     private static final int STATE_FRESH_INSTALL = 0;
     private static final int STATE_UPDATE = 2;
     private static final int STATE_NO_CHANGE = 1;
 
 
-    ServerRequestInitSession(Context context, String requestPath, SystemObserver systemObserver) {
+    ServerRequestInitSession(Context context, String requestPath) {
         super(context, requestPath);
         context_ = context;
-        systemObserver_ = systemObserver;
         contentDiscoveryManifest_ = ContentDiscoveryManifest.getInstance(context_);
     }
 
     ServerRequestInitSession(String requestPath, JSONObject post, Context context) {
         super(requestPath, post, context);
         context_ = context;
-        systemObserver_ = new SystemObserver(context);
         contentDiscoveryManifest_ = ContentDiscoveryManifest.getInstance(context_);
     }
 
     @Override
     protected void setPost(JSONObject post) throws JSONException {
         super.setPost(post);
-        if (!systemObserver_.getAppVersion().equals(SystemObserver.BLANK)) {
-            post.put(Defines.Jsonkey.AppVersion.getKey(), systemObserver_.getAppVersion());
+        String appVersion = DeviceInfo.getInstance().getAppVersion();
+        if (!DeviceInfo.isNullOrEmptyOrBlank(appVersion)) {
+            post.put(Defines.Jsonkey.AppVersion.getKey(), appVersion);
         }
         post.put(Defines.Jsonkey.FaceBookAppLinkChecked.getKey(), prefHelper_.getIsAppLinkTriggeredInit());
         post.put(Defines.Jsonkey.IsReferrable.getKey(), prefHelper_.getIsReferrable());
@@ -245,8 +243,8 @@ abstract class ServerRequestInitSession extends ServerRequest {
      */
     private void updateInstallStateAndTimestamps(JSONObject post) throws JSONException {
         int installOrUpdateState = STATE_NO_CHANGE;
-        String currAppVersion = systemObserver_.getAppVersion();
-        long updateBufferTime = 1 * (24 * 60 * 60 * 1000); // Update buffer time is a day.
+        String currAppVersion = DeviceInfo.getInstance().getAppVersion();
+        long updateBufferTime = (24 * 60 * 60 * 1000); // Update buffer time is a day.
         PackageInfo packageInfo = null;
         try {
             packageInfo = context_.getPackageManager().getPackageInfo(context_.getPackageName(), 0);

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterInstall.java
@@ -21,12 +21,11 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
      * @param context     Current {@link Application} context
      * @param callback    A {@link Branch.BranchReferralInitListener} callback instance that will return
      *                    the data associated with new install registration.
-     * @param sysObserver {@link SystemObserver} instance.
      * @param installID   installation ID.                                   .
      */
     ServerRequestRegisterInstall(Context context, Branch.BranchReferralInitListener callback,
-                                 SystemObserver sysObserver, String installID) {
-        super(context, Defines.RequestPath.RegisterInstall.getPath(), sysObserver);
+                                 String installID) {
+        super(context, Defines.RequestPath.RegisterInstall.getPath());
         callback_ = callback;
         JSONObject installPost = new JSONObject();
         try {
@@ -40,7 +39,7 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
         }
     }
     
-    public ServerRequestRegisterInstall(String requestPath, JSONObject post, Context context) {
+    ServerRequestRegisterInstall(String requestPath, JSONObject post, Context context) {
         super(requestPath, post, context);
     }
     
@@ -106,7 +105,7 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
                 callback_.onInitFinished(branch.getLatestReferringParams(), null);
             }
             
-            prefHelper_.setAppVersion(systemObserver_.getAppVersion());
+            prefHelper_.setAppVersion(DeviceInfo.getInstance().getAppVersion());
             
         } catch (Exception ex) {
             ex.printStackTrace();
@@ -115,7 +114,7 @@ class ServerRequestRegisterInstall extends ServerRequestInitSession {
     }
     
     
-    public void setInitFinishedCallback(Branch.BranchReferralInitListener callback) {
+    void setInitFinishedCallback(Branch.BranchReferralInitListener callback) {
         if (callback != null) {  // Update callback if set with valid callback instance.
             callback_ = callback;
         }

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterOpen.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterOpen.java
@@ -21,11 +21,9 @@ class ServerRequestRegisterOpen extends ServerRequestInitSession {
      * @param context     Current {@link Application} context
      * @param callback    A {@link Branch.BranchReferralInitListener} callback instance that will return
      *                    the data associated with new install registration.
-     * @param sysObserver {@link SystemObserver} instance.
      */
-    ServerRequestRegisterOpen(Context context, Branch.BranchReferralInitListener callback,
-                              SystemObserver sysObserver) {
-        super(context, Defines.RequestPath.RegisterOpen.getPath(), sysObserver);
+    ServerRequestRegisterOpen(Context context, Branch.BranchReferralInitListener callback) {
+        super(context, Defines.RequestPath.RegisterOpen.getPath());
         callback_ = callback;
         JSONObject openPost = new JSONObject();
         try {
@@ -94,7 +92,7 @@ class ServerRequestRegisterOpen extends ServerRequestInitSession {
                 callback_.onInitFinished(branch.getLatestReferringParams(), null);
             }
             
-            prefHelper_.setAppVersion(systemObserver_.getAppVersion());
+            prefHelper_.setAppVersion(DeviceInfo.getInstance().getAppVersion());
             
         } catch (Exception ex) {
             ex.printStackTrace();

--- a/Branch-SDK/src/io/branch/referral/ServerRequestRegisterView.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestRegisterView.java
@@ -1,7 +1,6 @@
 package io.branch.referral;
 
 import android.content.Context;
-import android.os.Build;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -12,7 +11,7 @@ import java.util.Set;
 import io.branch.indexing.BranchUniversalObject;
 
 /**
- * * <p>
+ * <p>
  * The server request for registering a view event of a specific content specified by user given attributes
  * </p>
  */
@@ -23,14 +22,14 @@ class ServerRequestRegisterView extends ServerRequest {
     /**
      * <p>Create an instance of {@link ServerRequestRegisterView} to notify Branch on a content view event.</p>
      *
-     * @param branchUniversalObject An instance of {@link BranchUniversalObject} to mar as viewed
+     * @param branchUniversalObject An instance of {@link BranchUniversalObject} to mark as viewed
      */
-    public ServerRequestRegisterView(Context context, BranchUniversalObject branchUniversalObject, SystemObserver sysObserver, BranchUniversalObject.RegisterViewStatusListener callback) {
+    public ServerRequestRegisterView(Context context, BranchUniversalObject branchUniversalObject, BranchUniversalObject.RegisterViewStatusListener callback) {
         super(context, Defines.RequestPath.RegisterView.getPath());
         callback_ = callback;
         JSONObject registerViewPost;
         try {
-            registerViewPost = createContentViewJson(branchUniversalObject, sysObserver);
+            registerViewPost = createContentViewJson(branchUniversalObject);
             setPost(registerViewPost);
         } catch (JSONException ex) {
             ex.printStackTrace();
@@ -80,30 +79,21 @@ class ServerRequestRegisterView extends ServerRequest {
      * @return A {@link JSONObject} for post data for register view request
      * @throws JSONException {@link JSONException} on any Json errors
      */
-    private JSONObject createContentViewJson(BranchUniversalObject universalObject,
-                                             SystemObserver sysObserver) throws JSONException {
-
+    private JSONObject createContentViewJson(BranchUniversalObject universalObject) throws JSONException {
         JSONObject contentObject = new JSONObject();
 
-
-        String os_Info = "Android " + Build.VERSION.SDK_INT;
         String sessionID = prefHelper_.getSessionID();
 
         contentObject.put(Defines.Jsonkey.SessionID.getKey(), sessionID);
         contentObject.put(Defines.Jsonkey.DeviceFingerprintID.getKey(), prefHelper_.getDeviceFingerPrintID());
 
-        String uniqueId;
-        if (DeviceInfo.getInstance() != null) {
-            uniqueId = DeviceInfo.getInstance().getHardwareID();
-        } else {
-            uniqueId = sysObserver.getUniqueID(BranchUtil.isDebugEnabled());
-        }
-        if (!uniqueId.equals(SystemObserver.BLANK) && sysObserver.hasRealHardwareId()) {
+        SystemObserver.UniqueId uniqueId = DeviceInfo.getInstance().getHardwareID();
+        if (!DeviceInfo.isNullOrEmptyOrBlank(uniqueId.getId()) && uniqueId.isReal()) {
             contentObject.put(Defines.Jsonkey.HardwareID.getKey(), uniqueId);
         }
 
-        String appVersion = sysObserver.getAppVersion();
-        if (!appVersion.equals(SystemObserver.BLANK)) {
+        String appVersion = DeviceInfo.getInstance().getAppVersion();
+        if (!DeviceInfo.isNullOrEmptyOrBlank(appVersion)) {
             contentObject.put(Defines.Jsonkey.AppVersion.getKey(), appVersion);
         }
 


### PR DESCRIPTION
## Reference
SDK-230 -- Unwind SystemObserver

## Description
SystemObserver.java is used to collect things like advertising IDs, Hardware IDs, etc. The usage of this class is a bit convoluted, and because of statics and copies of these classes it isn't always working as expected.

For example, calls through DeviceInfo.java will only use the very first SystemObserver (because of a static), where other calls to a SystemObserver can be made returning completely different results. "disableDeviceIDFetch_" is one such variable, that depending on which direction a call is made from, will set different values in a payload.

## Testing Instructions
* Sample app should continue to function.
* Unit tests should all pass

## Notes
Unwinding this was a little more than I had hoped when first undertaking this task.  I essentially removed the ability to construct a SystemObserver outside of DeviceInfo.

## Risk Assessment [`MEDIUM`]
The code changes affected a lot of areas, and a lot of internal method signatures.  While the behavior might be slightly different when moving in and out of debug, test, or simulation mode -- it should now be internally consistent regardless of where the call is coming from.

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)