### PR TITLE
SDK-271 -- Customer wants to be able to create short links from the SDK even when they disable tracking

### DIFF
--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2319,7 +2319,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                             handleFailure(requestQueue_.getSize() - 1, BranchError.ERR_NO_SESSION);
                         }
                         //All request except open and install need a session to execute
-                        else if (!(req instanceof ServerRequestInitSession) && (!hasSession() || !hasDeviceFingerPrint())) {
+                        else if (needsSession(req)) {
                             networkCount_ = 0;
                             handleFailure(requestQueue_.getSize() - 1, BranchError.ERR_NO_SESSION);
                         } else {
@@ -2338,6 +2338,18 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    private boolean needsSession(ServerRequest request) {
+        // All request except open and install need a session to execute (TODO -- Incorrect comment)
+        if (request instanceof ServerRequestInitSession) {
+            return false;
+        } else if (request instanceof ServerRequestCreateUrl) {
+            return false;
+        }
+
+        boolean sessionAvailable = (hasSession() || hasDeviceFingerPrint());
+        return !sessionAvailable;
     }
     
     private void handleFailure(int index, int statusCode) {
@@ -2565,7 +2577,7 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
      */
     public void handleNewRequest(ServerRequest req) {
         // If Tracking is disabled fail all messages with ERR_BRANCH_TRACKING_DISABLED
-        if (trackingController.isTrackingDisabled()) {
+        if (trackingController.isTrackingDisabled() && !req.prepareExecuteWithoutTracking()) {
             req.reportTrackingDisabledError();
             return;
         }

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2318,8 +2318,8 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
                             networkCount_ = 0;
                             handleFailure(requestQueue_.getSize() - 1, BranchError.ERR_NO_SESSION);
                         }
-                        //All request except open and install need a session to execute
-                        else if (needsSession(req)) {
+                        // Determine if a session is needed to execute (SDK-271)
+                        else if (requestNeedsSession(req) && !isSessionAvailableForRequest()) {
                             networkCount_ = 0;
                             handleFailure(requestQueue_.getSize() - 1, BranchError.ERR_NO_SESSION);
                         } else {
@@ -2340,15 +2340,21 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
         }
     }
 
-    private boolean needsSession(ServerRequest request) {
+    // Determine if a Request needs a Session to proceed.
+    private boolean requestNeedsSession(ServerRequest request) {
         if (request instanceof ServerRequestInitSession) {
             return false;
         } else if (request instanceof ServerRequestCreateUrl) {
             return false;
         }
 
-        boolean sessionAvailable = (hasSession() || hasDeviceFingerPrint());
-        return !sessionAvailable;
+        // All other Request Types need a session.
+        return true;
+    }
+
+    // Determine if a Session is available for a Request to proceed.
+    private boolean isSessionAvailableForRequest() {
+        return (hasSession() && hasDeviceFingerPrint());
     }
     
     private void handleFailure(int index, int statusCode) {

--- a/Branch-SDK/src/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/io/branch/referral/Branch.java
@@ -2341,7 +2341,6 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     }
 
     private boolean needsSession(ServerRequest request) {
-        // All request except open and install need a session to execute (TODO -- Incorrect comment)
         if (request instanceof ServerRequestInitSession) {
             return false;
         } else if (request instanceof ServerRequestCreateUrl) {

--- a/Branch-SDK/src/io/branch/referral/ServerRequestCreateUrl.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestCreateUrl.java
@@ -273,4 +273,11 @@ class ServerRequestCreateUrl extends ServerRequest {
     boolean isPersistable() {
         return false; // No need to retrieve create url request from previous session
     }
+
+    @Override
+    protected boolean prepareExecuteWithoutTracking() {
+        // SDK-271 -- Allow creation of short links when tracking is disabled.
+        return true;
+    }
+
 }


### PR DESCRIPTION
## Reference
SDK-271 -- Customer wants to be able to create short links from the SDK even when they disable tracking

## Description
The SDK disables creating short links from the SDK when tracking is disabled. We want to change this so that you can still create short links.

## Testing Instructions
* Sample app should continue to function.
* Unit tests should all pass

The way that I tested this was to use the Branch-SDK-TestBed app and disable tracking, then refresh the URL.   I also verified that the URL can be updated with tracking enabled.

## Risk Assessment [`MEDIUM`]
There is a piece of logic that was a complicated piece of negative logic.   Please carefully review Branch.java around the new method `needsSession()`

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)