### PR TITLE
SDK-254 -- Customer reported exception accessing dead package manager 

### DIFF
--- a/Branch-SDK/src/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/io/branch/referral/DeviceInfo.java
@@ -57,7 +57,7 @@ class DeviceInfo {
      *
      * @param requestObj JSON object for Branch server request
      */
-    public void updateRequestWithV1Params(JSONObject requestObj) {
+    void updateRequestWithV1Params(JSONObject requestObj) {
         try {
             SystemObserver.UniqueId hardwareID = getHardwareID();
             if (!isNullOrEmptyOrBlank(hardwareID.getId())) {
@@ -115,7 +115,7 @@ class DeviceInfo {
      *
      * @param requestObj JSON object for Branch server request
      */
-    public void updateRequestWithV2Params(Context context, PrefHelper prefHelper, JSONObject requestObj) {
+    void updateRequestWithV2Params(Context context, PrefHelper prefHelper, JSONObject requestObj) {
         try {
             SystemObserver.UniqueId hardwareID = getHardwareID();
             if (!isNullOrEmptyOrBlank(hardwareID.getId()) && hardwareID.isReal()) {
@@ -185,7 +185,7 @@ class DeviceInfo {
      * @return {@link String} with package name value
      */
     public String getPackageName() {
-        return systemObserver_.getPackageName(context_);
+        return SystemObserver.getPackageName(context_);
     }
 
     /**
@@ -194,7 +194,29 @@ class DeviceInfo {
      * @return {@link String} with app version value
      */
     public String getAppVersion() {
-        return systemObserver_.getAppVersion(context_);
+        return SystemObserver.getAppVersion(context_);
+    }
+
+    /**
+     * @return the time at which the app was first installed, in milliseconds.
+     */
+    public long getFirstInstallTime() {
+        return SystemObserver.getFirstInstallTime(context_);
+    }
+
+    /**
+     * @return the time at which the app was last updated, in milliseconds.
+     */
+    public long getLastUpdateTime() {
+        return SystemObserver.getLastUpdateTime(context_);
+    }
+
+    /**
+     * Determine if the package is installed, vs. if this is an "Instant" app.
+     * @return true if the package is installed.
+     */
+    public boolean isPackageInstalled() {
+        return SystemObserver.isPackageInstalled(context_);
     }
 
     /**

--- a/Branch-SDK/src/io/branch/referral/PrefHelper.java
+++ b/Branch-SDK/src/io/branch/referral/PrefHelper.java
@@ -23,6 +23,7 @@ import java.util.Collections;
  * preference values.</p>
  */
 public class PrefHelper {
+    private static final String TAG = "BranchSDK";
 
     /**
      * The base URL to use for all calls to the Branch API.
@@ -1153,14 +1154,20 @@ public class PrefHelper {
     public static void Debug(String message) {
         if (BranchUtil.isDebugEnabled() || enableLogging_) {
             if (!TextUtils.isEmpty(message)) {
-                Log.i("BranchSDK", message);
+                Log.i(TAG, message);
             }
+        }
+    }
+
+    public static void LogException(String message, Throwable t) {
+        if (!TextUtils.isEmpty(message)) {
+            Log.e(TAG, message, t);
         }
     }
 
     public static void LogAlways(String message) {
         if (!TextUtils.isEmpty(message)) {
-            Log.i("BranchSDK", message);
+            Log.i(TAG, message);
         }
     }
 

--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -2,9 +2,7 @@ package io.branch.referral;
 
 import android.Manifest;
 import android.content.Context;
-import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.text.TextUtils;
 
 import org.json.JSONException;
@@ -13,7 +11,6 @@ import org.json.JSONObject;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -26,10 +23,9 @@ public abstract class ServerRequest {
     private static final String POST_PATH_KEY = "REQ_POST_PATH";
 
     private JSONObject params_;
-    protected String requestPath_;
+    private String requestPath_;
     protected final PrefHelper prefHelper_;
-    long queueWaitTime_ = 0;
-    private int waitLockCnt = 0;
+    private long queueWaitTime_ = 0;
     private final Context context_;
     
     // Various process wait locks for Branch server request
@@ -39,7 +35,7 @@ public abstract class ServerRequest {
     }
     
     // Set for holding any active wait locks
-    final Set<PROCESS_WAIT_LOCK> locks_;
+    private final Set<PROCESS_WAIT_LOCK> locks_;
     
     /*True if there is an error in creating this request such as error with json parameters.*/
     public boolean constructError_ = false;

--- a/Branch-SDK/src/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequest.java
@@ -573,7 +573,7 @@ public abstract class ServerRequest {
     
     protected void updateEnvironment(Context context, JSONObject post) {
         try {
-            String environment = isPackageInstalled(context) ? Defines.Jsonkey.NativeApp.getKey() : Defines.Jsonkey.InstantApp.getKey();
+            String environment = DeviceInfo.getInstance().isPackageInstalled() ? Defines.Jsonkey.NativeApp.getKey() : Defines.Jsonkey.InstantApp.getKey();
             if (getBranchRemoteAPIVersion() == BRANCH_API_VERSION.V2) {
                 JSONObject userData = post.optJSONObject(Defines.Jsonkey.UserData.getKey());
                 if (userData != null) {
@@ -585,17 +585,7 @@ public abstract class ServerRequest {
         } catch (Exception ignore) {
         }
     }
-    
-    private static boolean isPackageInstalled(Context context) {
-        final PackageManager packageManager = context.getPackageManager();
-        Intent intent = packageManager.getLaunchIntentForPackage(context.getPackageName());
-        if (intent == null) {
-            return false;
-        }
-        List<ResolveInfo> list = packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
-        return (list != null && list.size() > 0);
-    }
-    
+
     /**
      * Returns the Branch API version
      *

--- a/Branch-SDK/src/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestInitSession.java
@@ -2,8 +2,6 @@ package io.branch.referral;
 
 import android.app.Activity;
 import android.content.Context;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/Branch-SDK/src/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/io/branch/referral/ServerRequestInitSession.java
@@ -245,16 +245,15 @@ abstract class ServerRequestInitSession extends ServerRequest {
         int installOrUpdateState = STATE_NO_CHANGE;
         String currAppVersion = DeviceInfo.getInstance().getAppVersion();
         long updateBufferTime = (24 * 60 * 60 * 1000); // Update buffer time is a day.
-        PackageInfo packageInfo = null;
-        try {
-            packageInfo = context_.getPackageManager().getPackageInfo(context_.getPackageName(), 0);
-        } catch (PackageManager.NameNotFoundException ignored) {
-        }
+
+        long firstInstallTime = DeviceInfo.getInstance().getFirstInstallTime();
+        long lastUpdateTime = DeviceInfo.getInstance().getLastUpdateTime();
+
         if (PrefHelper.NO_STRING_VALUE.equals(prefHelper_.getAppVersion())) {
             // Default, just register an install
             installOrUpdateState = STATE_FRESH_INSTALL;
             // if no app version is in storage, this must be the first time Branch is here. 24 hour buffer for updating as an update state
-            if (packageInfo != null && (packageInfo.lastUpdateTime - packageInfo.firstInstallTime) >= updateBufferTime) {
+            if ((lastUpdateTime - firstInstallTime) >= updateBufferTime) {
                 installOrUpdateState = STATE_UPDATE;
             }
         } else if (!prefHelper_.getAppVersion().equals(currAppVersion)) {
@@ -263,23 +262,21 @@ abstract class ServerRequestInitSession extends ServerRequest {
         }
 
         post.put(Defines.Jsonkey.Update.getKey(), installOrUpdateState);
-        if (packageInfo != null) {
-            post.put(Defines.Jsonkey.FirstInstallTime.getKey(), packageInfo.firstInstallTime);
-            post.put(Defines.Jsonkey.LastUpdateTime.getKey(), packageInfo.lastUpdateTime);
-            long originalInstallTime = prefHelper_.getLong(PrefHelper.KEY_ORIGINAL_INSTALL_TIME);
-            if (originalInstallTime == 0) {
-                originalInstallTime = packageInfo.firstInstallTime;
-                prefHelper_.setLong(PrefHelper.KEY_ORIGINAL_INSTALL_TIME, packageInfo.firstInstallTime);
-            }
-            post.put(Defines.Jsonkey.OriginalInstallTime.getKey(), originalInstallTime);
-
-            long lastKnownUpdateTime = prefHelper_.getLong(PrefHelper.KEY_LAST_KNOWN_UPDATE_TIME);
-            if (lastKnownUpdateTime < packageInfo.lastUpdateTime) {
-                prefHelper_.setLong(PrefHelper.KEY_PREVIOUS_UPDATE_TIME, lastKnownUpdateTime);
-                prefHelper_.setLong(PrefHelper.KEY_LAST_KNOWN_UPDATE_TIME, packageInfo.lastUpdateTime);
-            }
-            post.put(Defines.Jsonkey.PreviousUpdateTime.getKey(), prefHelper_.getLong(PrefHelper.KEY_PREVIOUS_UPDATE_TIME));
+        post.put(Defines.Jsonkey.FirstInstallTime.getKey(), firstInstallTime);
+        post.put(Defines.Jsonkey.LastUpdateTime.getKey(), lastUpdateTime);
+        long originalInstallTime = prefHelper_.getLong(PrefHelper.KEY_ORIGINAL_INSTALL_TIME);
+        if (originalInstallTime == 0) {
+            originalInstallTime = firstInstallTime;
+            prefHelper_.setLong(PrefHelper.KEY_ORIGINAL_INSTALL_TIME, firstInstallTime);
         }
+        post.put(Defines.Jsonkey.OriginalInstallTime.getKey(), originalInstallTime);
+
+        long lastKnownUpdateTime = prefHelper_.getLong(PrefHelper.KEY_LAST_KNOWN_UPDATE_TIME);
+        if (lastKnownUpdateTime < lastUpdateTime) {
+            prefHelper_.setLong(PrefHelper.KEY_PREVIOUS_UPDATE_TIME, lastKnownUpdateTime);
+            prefHelper_.setLong(PrefHelper.KEY_LAST_KNOWN_UPDATE_TIME, lastUpdateTime);
+        }
+        post.put(Defines.Jsonkey.PreviousUpdateTime.getKey(), prefHelper_.getLong(PrefHelper.KEY_PREVIOUS_UPDATE_TIME));
     }
 
     @Override


### PR DESCRIPTION
## Reference
SDK-254 -- Customer reported exception accessing dead package manager (SystemObserver.getAppVersion())

GitHub issue https://github.com/BranchMetrics/android-branch-deep-linking/issues/488
GitHub issue https://github.com/BranchMetrics/android-branch-deep-linking/issues/680

## Description
Rare crashes with PackageManager throwing "Package manager has died" exception.

While I have not reproduced in house,  the SDK doesn't protect against all exceptions, just NameNotFoundException.  

To harden the SDK, I am pulling most access to the PackageManager into the SystemObserver class, and wrapping all with full exception handling.   There are a couple of other usages that I did not move as they required more involved refactoring.

## Testing Instructions
* Sample app should continue to function.
* Unit tests should all pass

## Risk Assessment [`LOW`]
I am touching rather more code than I would like, but there shouldn't be any logic changes.

- [X] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [x] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [x] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [x] Mission critical pieces are documented in code and out of code as needed
- [x] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)