### PR TITLE
SDK-283 -- testGAIDFetch asserts an incorrect value

### DIFF
--- a/Branch-SDK/androidTest/io/branch/referral/DeviceInfoTest.java
+++ b/Branch-SDK/androidTest/io/branch/referral/DeviceInfoTest.java
@@ -80,6 +80,5 @@ public class DeviceInfoTest extends BranchTest {
         }
 
         Assert.assertFalse(DeviceInfo.isNullOrEmptyOrBlank(DeviceInfo.getInstance().getSystemObserver().getGAID()));
-        Assert.assertNotEquals(0, DeviceInfo.getInstance().getSystemObserver().getLATVal());
     }
 }


### PR DESCRIPTION
## Reference
SDK-283 -- testGAIDFetch asserts an incorrect value

## Description
When writing the unit test for `testGAIDFetch()`, I wrongly asserted that LATValue() should not be zero.

Typical devices have this value at zero -- it is a manual switch to turn on.   Since this cannot be asserted, the assertion was removed.

## Testing Instructions
* Sample app should continue to function.
* Unit tests should all pass

## Risk Assessment [`LOW`]
Unit test only

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [x] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [x] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [x] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)