### PR TITLE
SDK-151 -- Enable build and test automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/code
+    docker:
+      - image: circleci/android:api-28
+    steps:
+      - checkout
+      - run:
+          name: Run Lint
+          command: ./gradlew lint
+      - run:
+          name: Run Build
+          command: ./gradlew build
+      - store_artifacts:
+          path: ./Branch-SDK/build/outputs/aar/


### PR DESCRIPTION
## Reference
SDK-151 -- Enable build and test automation

## Description
Build ~~and Run Tests~~ on CircleCI

Note that unit test framework will be done in a later ticket due to CircleCI not able to handle the test environment.

## Testing Instructions
* Sample app should continue to function.
* Unit tests should all pass
* CircleCI Integration Succeeds

## Risk Assessment [`LOW`]
This is only a CircleCI Integration effort.  

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in MR title
- Correctness & Style
    - [ ] Conforms to [Style Guides](https://google.github.io/styleguide/javaguide.html)
    - [ ] Mission critical pieces are documented in code and out of code as needed
- [ ] Unit Tests reviewed and test issue sufficiently
- [ ] Functionality was reviewed in QA independently by another engineer on the team (clone for each required reviewer)