### PR TITLE
Fixed branch session reinitialization warning being thrown in onInitFinished()

### DIFF
--- a/Branch-SDK/build.gradle
+++ b/Branch-SDK/build.gradle
@@ -49,6 +49,10 @@ android {
             testCoverageEnabled true
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 //------------- Jar Generation code. ---------------//

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2072,6 +2072,38 @@ public class Branch implements BranchViewHandler.IBranchViewEvents, SystemObserv
     public interface BranchReferralInitListener {
         void onInitFinished(@Nullable JSONObject referringParams, @Nullable BranchError error);
     }
+
+    /**
+     * <p>An Interface class that is implemented by all classes that make use of
+     * {@link BranchReferralInitListener2}, defining 3 methods that takes a list of params in
+     * {@link JSONObject} format, and an error message of {@link BranchError} format that will be
+     * returned on failure/warning of the request response.</p>
+     *
+     * @see JSONObject
+     * @see BranchError
+     */
+    public interface BranchReferralInitListener2 extends BranchReferralInitListener {
+        void onError(BranchError error);
+
+        void onWarning(BranchError warning);
+
+        void onFinished(JSONObject referringParams);
+
+        @Override
+        default void onInitFinished(@Nullable JSONObject referringParams, @Nullable BranchError error) {
+            if (referringParams != null) {
+                onFinished(referringParams);
+                return;
+            }
+            if (error != null) {
+                if (error.errorMessage_.startsWith("Warning.")) {
+                    onWarning(error);
+                } else {
+                    onError(error);
+                }
+            }
+        }
+    }
     
     /**
      * <p>An Interface class that is implemented by all classes that make use of


### PR DESCRIPTION
## Reference
SDK-5.0.0

## Description
Fixed the issue wherein branch session reinitialization warning is being sent to onInitFinished() method all the time. Clearly segregated error, warning and success case for BranchReferralInitListener. Updated java 8 support

## Testing Instructions
Go to the activity other than Branch launcher activity and come back to the Branch launcher activity. onWarning method is called to throw branch reinitialization warning.

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
LOW

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.
