### PR TITLE
[EMT-3325] Fix getLastAttributedTouchData function default

### DIFF
--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/MainActivity.java
@@ -49,6 +49,7 @@ import io.branch.referral.BranchLogger;
 import io.branch.referral.Defines;
 import io.branch.referral.PrefHelper;
 import io.branch.referral.QRCode.BranchQRCode;
+import io.branch.referral.ServerRequestGetLATD;
 import io.branch.referral.SharingHelper;
 import io.branch.referral.util.BRANCH_STANDARD_EVENT;
 import io.branch.referral.util.BranchContentSchema;
@@ -702,6 +703,22 @@ public class MainActivity extends Activity {
                             }
                         }
                     }).withData(MainActivity.this.getIntent().getData()).init();
+                } catch (Exception e) {
+                    Log.e("BranchSDK_Tester", e.getMessage());
+                }
+            }
+        });
+
+        findViewById(R.id.getLatdButton).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                try {
+                    Branch.getInstance().getLastAttributedTouchData(new ServerRequestGetLATD.BranchLastAttributedTouchDataListener() {
+                        @Override
+                        public void onDataFetched(JSONObject jsonObject, BranchError error) {
+                            Log.i("BranchSDK_Tester", "Result: " + String.valueOf(jsonObject) + "\nError: " + error);
+                        }
+                    });
                 } catch (Exception e) {
                     Log.e("BranchSDK_Tester", e.getMessage());
                 }

--- a/Branch-SDK-TestBed/src/main/res/layout/main_activity.xml
+++ b/Branch-SDK-TestBed/src/main/res/layout/main_activity.xml
@@ -134,6 +134,12 @@
                 />
 
             <Button
+                android:id="@+id/getLatdButton"
+                style="@style/testbed_button_style"
+                android:drawableStart="@drawable/baseline_document_scanner_24"
+                android:text="Get Last Attributed Touch Data" />
+
+            <Button
                 android:id="@+id/initSessionButton"
                 style="@style/testbed_button_style"
                 android:drawableStart="@drawable/baseline_document_scanner_24"

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchCPIDTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchCPIDTest.java
@@ -89,6 +89,5 @@ public class BranchCPIDTest extends BranchTest {
         Assert.assertNotNull(postBody);
         JSONObject userData = postBody.optJSONObject(Defines.Jsonkey.UserData.getKey());
         Assert.assertNotNull(userData);
-        Assert.assertNull(userData.optJSONObject(Defines.Jsonkey.LATDAttributionWindow.getKey()));
-    }
+        Assert.assertFalse(userData.has(Defines.Jsonkey.LATDAttributionWindow.getKey()));    }
 }

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchCPIDTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchCPIDTest.java
@@ -89,5 +89,6 @@ public class BranchCPIDTest extends BranchTest {
         Assert.assertNotNull(postBody);
         JSONObject userData = postBody.optJSONObject(Defines.Jsonkey.UserData.getKey());
         Assert.assertNotNull(userData);
-        Assert.assertFalse(userData.has(Defines.Jsonkey.LATDAttributionWindow.getKey()));    }
+        Assert.assertFalse(userData.has(Defines.Jsonkey.LATDAttributionWindow.getKey()));
+    }
 }

--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchCPIDTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchCPIDTest.java
@@ -73,4 +73,22 @@ public class BranchCPIDTest extends BranchTest {
         int atrWind = userData.optInt(Defines.Jsonkey.LATDAttributionWindow.getKey());
         Assert.assertEquals(10, atrWind);
     }
+
+    @Test
+    public void testDefaultAttributionWindowValueNotPresent() {
+        //setup
+        initBranchInstance();
+        branch.getLastAttributedTouchData(null);
+        ServerRequestQueue queue = ServerRequestQueue.getInstance(getTestContext());
+        Assert.assertEquals(1, queue.getSize());
+
+        ServerRequest latdRequest = queue.peekAt(0);
+        Assert.assertTrue(latdRequest instanceof ServerRequestGetLATD);
+
+        JSONObject postBody = latdRequest.getPost();
+        Assert.assertNotNull(postBody);
+        JSONObject userData = postBody.optJSONObject(Defines.Jsonkey.UserData.getKey());
+        Assert.assertNotNull(userData);
+        Assert.assertNull(userData.optJSONObject(Defines.Jsonkey.LATDAttributionWindow.getKey()));
+    }
 }

--- a/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/DeviceInfo.java
@@ -217,8 +217,13 @@ class DeviceInfo {
             setPostUserAgent(userDataObj);
 
             if (serverRequest instanceof ServerRequestGetLATD) {
-                userDataObj.put(Defines.Jsonkey.LATDAttributionWindow.getKey(),
-                        ((ServerRequestGetLATD) serverRequest).getAttributionWindow());
+                // If window is not set by the sdk, do not send `attribution_window`
+                // Server will return configured default
+                // Server will enforce window cap
+                int attribution_window = ((ServerRequestGetLATD) serverRequest).getAttributionWindow();
+                if (attribution_window > 0) {
+                    userDataObj.put(Defines.Jsonkey.LATDAttributionWindow.getKey(), attribution_window);
+                }
             }
 
             if (serverRequest.isInitializationOrEventRequest()) {

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestGetLATD.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestGetLATD.java
@@ -8,7 +8,6 @@ import org.json.JSONObject;
 public class ServerRequestGetLATD extends ServerRequest {
 
     private BranchLastAttributedTouchDataListener callback;
-    // defaultAttributionWindow is the "default" for the SDK's side, server interprets it as 30 days
     protected static final int defaultAttributionWindow = -1;
     private int attributionWindow;
 


### PR DESCRIPTION
## Reference
SDK-XXX -- <TITLE>.

## Description
When using the function
```
Branch.getInstance().getLastAttributedTouchData(new ServerRequestGetLATD.BranchLastAttributedTouchDataListener() {
    @Override
     public void onDataFetched(JSONObject jsonObject, BranchError error) {
      ...
     }
});
```
With no attribution window set, the SDK sets an internal value of -1 for the window. However, sending this value results in 
```
{"last_attributed_touch_data":null,"attribution_window":null}
```

being returned.

The expectation of this function is to return the dashboard configured value if no window is set. This PR adds a check to see if there has been a value set by the `getLastAttributedTouchData` function, and if so, send that value as before. Else, do not include an invalid `attribution_window` and allow the server to return what is configured.

## Testing Instructions
Checkout the branch and use in an application that has this feature enabled. Ensure no regression when using
```
Branch.getInstance().getLastAttributedTouchData(new ServerRequestGetLATD.BranchLastAttributedTouchDataListener() {
    @Override
     public void onDataFetched(JSONObject jsonObject, BranchError error) {
      ...
     }
}, ATTRIBUTION_WINDOW);
```
where `ATTRIBUTION_WINDOW` is an optional integer parameter.

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
