### PR TITLE
Release 5.21.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,7 @@
 # Branch Android SDK change log
+- v5.21.1
+  - Fix for `getLastAttributedTouchData(BranchLastAttributedTouchDataListener())` with no parameter, now correctly uses attribution window value configured in app dashboard.
+  
 - v5.21.0
   - Add an optional configuration to allow cancelling Install Referrer fetch.
     - `setInstallReferrerTimeout(int timeoutInMilliseconds)`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 # Branch Android SDK change log
 - v5.21.1
-  - Fix for `getLastAttributedTouchData(BranchLastAttributedTouchDataListener())` with no parameter, now correctly uses attribution window value configured in app dashboard.
-  
+  - Fix for `getLastAttributedTouchData(BranchLastAttributedTouchDataListener())` with no `attributionWindow` parameter, now correctly uses attribution window value configured in app dashboard.
+
 - v5.21.0
   - Add an optional configuration to allow cancelling Install Referrer fetch.
     - `setInstallReferrerTimeout(int timeoutInMilliseconds)`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=5.21.0
-VERSION_CODE=052500
+VERSION_NAME=5.21.1
+VERSION_CODE=052501
 GROUP=io.branch.sdk.android
 
 POM_DESCRIPTION=Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it is really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.


### PR DESCRIPTION
- v5.21.1
  - Fix for `getLastAttributedTouchData(BranchLastAttributedTouchDataListener())` with no parameter, now correctly uses attribution window value configured in app dashboard.

## Reference
SDK-XXX -- <TITLE>.

## Description
<!-- SUFFICIENT DESCRIPTION TO EXPLAIN THE PROBLEM THAT IS BEING SOLVED -->

## Testing Instructions
<!-- TESTING INSTRUCTIONS -->

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
