### PR TITLE
Fix androidTest compilation (canClearInitData port + setInitState signature)

### DIFF
--- a/Branch-SDK/src/androidTest/java/io/branch/referral/BranchTest.java
+++ b/Branch-SDK/src/androidTest/java/io/branch/referral/BranchTest.java
@@ -48,7 +48,7 @@ abstract public class BranchTest extends BranchTestRequestUtil {
         }
 
         if (branch != null) {
-            branch.setInitState(Branch.SESSION_STATE.UNINITIALISED);
+            branch.setInitState(BranchSessionState.Uninitialized.INSTANCE);
             Branch.shutDown();
             branch = null;
         }

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchRequestQueue.kt
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchRequestQueue.kt
@@ -919,6 +919,17 @@ class BranchRequestQueue private constructor(private val context: Context) {
     }
     
     /**
+     * Whether the queue can clear init data: true when at most one init request remains
+     * (the one currently being removed). Mirrors ServerRequestQueue.canClearInitData() so the
+     * modern adapter keeps API parity with the legacy queue.
+     */
+    fun canClearInitData(): Boolean {
+        synchronized(queueList) {
+            return queueList.count { it is ServerRequestInitSession } <= 1
+        }
+    }
+
+    /**
      * Unlock process wait (matches original API)
      */
     fun unlockProcessWait(lock: ServerRequest.PROCESS_WAIT_LOCK) {

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchRequestQueueAdapter.kt
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchRequestQueueAdapter.kt
@@ -210,6 +210,16 @@ class BranchRequestQueueAdapter private constructor(context: Context) {
     }
     
     /**
+     * Whether init data can be cleared (delegates to the modern queue). Matches the legacy
+     * ServerRequestQueue API so callers and tests written against it keep compiling.
+     */
+    fun canClearInitData(): Boolean {
+        val result = newQueue.canClearInitData()
+        BranchLogger.d("DEBUG: BranchRequestQueueAdapter.canClearInitData result: $result")
+        return result
+    }
+
+    /**
      * Instrumentation and debugging
      */
     fun addExtraInstrumentationData(key: String, value: String) {

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchRequestQueueAdapter.kt
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchRequestQueueAdapter.kt
@@ -215,7 +215,6 @@ class BranchRequestQueueAdapter private constructor(context: Context) {
      */
     fun canClearInitData(): Boolean {
         val result = newQueue.canClearInitData()
-        BranchLogger.d("DEBUG: BranchRequestQueueAdapter.canClearInitData result: $result")
         return result
     }
 


### PR DESCRIPTION
## Summary

The `androidTest` source set has not compiled since [5fab3857](https://github.com/BranchMetrics/android-branch-deep-linking-attribution/commit/5fab3857) (EMT-2260), due to two migration breakages in the test harness. This blocks the entire instrumented suite from building or running.

## Changes

1. **`canClearInitData` parity** — `BranchMigrationTest` calls `adapter.canClearInitData()`, which existed only on the legacy `ServerRequestQueue` and was never ported to `BranchRequestQueueAdapter`. Added `canClearInitData()` to `BranchRequestQueue` (counts queued `ServerRequestInitSession`, true when ≤1 remains) and delegated from the adapter.
2. **`setInitState` signature** — `BranchTest.tearDown()` passed the legacy `Branch.SESSION_STATE.UNINITIALISED` enum to `setInitState`, which now takes a `BranchSessionState`. Use `BranchSessionState.Uninitialized`.

## Verification

`./gradlew :Branch-SDK:compileDebugAndroidTestJavaWithJavac` → BUILD SUCCESSFUL (previously failed on `Unresolved reference: canClearInitData` then `SESSION_STATE cannot be converted to BranchSessionState`).

## Why this matters

The instrumented suite being uncompilable since 5fab3857, together with the `unit-and-instrumented-tests` workflow being disabled, means the cold-start regressions tracked in EMT-3859 / EMT-3860 shipped to beta with no instrumented coverage running. This unblocks that coverage and is a prerequisite for the EMT-3860 cold-start regression test.