### PR TITLE
EMT-3860 -- Restore cold-start intent-pending wait lock to fix dropped deep link attribution

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/coroutines/RequestOpen.kt
+++ b/Branch-SDK/src/main/java/io/branch/coroutines/RequestOpen.kt
@@ -67,7 +67,10 @@ internal class RequestOpen(
                 }
 
                 if (callback_ != null) {
-                    //TODO: This will not have any link data
+                    // EMT-3860: latestReferringParams now carries the resolved deep link data,
+                    // because the open POST includes external_intent_uri (via the inherited
+                    // ServerRequestInitSession.onPreExecute) so the server resolves the click and
+                    // returns link_data in the response.
                     callback_!!.onInitFinished(branch.latestReferringParams, null)
                 }
             }

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1432,7 +1432,10 @@ public class Branch {
 
         // Single top activities can be launched from stack and there may be a new intent provided with onNewIntent() call.
         // In this case need to wait till onResume to get the latest intent.
-        if (false) {
+        // EMT-3860: hold the init request until the launch intent has been parsed (onIntentReady
+        // sets INTENT_STATE.READY), so the install/open POST carries external_intent_uri /
+        // link_identifier on a cold start instead of firing before the intent is read.
+        if (intentState_ != INTENT_STATE.READY) {
             request.addProcessWaitLock(ServerRequest.PROCESS_WAIT_LOCK.INTENT_PENDING_WAIT_LOCK);
             BranchLogger.v("Added INTENT_PENDING_WAIT_LOCK");
         }
@@ -1489,16 +1492,21 @@ public class Branch {
     }
     
     void onIntentReady(@NonNull Activity activity) {
-        BranchLogger.v("onIntentReady " + activity + " removing INTENT_PENDING_WAIT_LOCK");
+        BranchLogger.v("onIntentReady " + activity);
         setIntentState(Branch.INTENT_STATE.READY);
-        requestQueue_.unlockProcessWait(ServerRequest.PROCESS_WAIT_LOCK.INTENT_PENDING_WAIT_LOCK);
 
+        // EMT-3860: read and persist the launch-intent params (external_intent_uri /
+        // link_identifier) BEFORE releasing the wait lock, so the queued init request sends with
+        // the link data instead of racing the unlock and going out empty.
         boolean grabIntentParams = activity.getIntent() != null && !(getInitState() instanceof BranchSessionState.Initialized);
 
         if (grabIntentParams) {
             Uri intentData = activity.getIntent().getData();
             readAndStripParam(intentData, activity);
         }
+
+        BranchLogger.v("onIntentReady removing INTENT_PENDING_WAIT_LOCK");
+        requestQueue_.unlockProcessWait(ServerRequest.PROCESS_WAIT_LOCK.INTENT_PENDING_WAIT_LOCK);
     }
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchRequestQueue.kt
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchRequestQueue.kt
@@ -574,6 +574,14 @@ class BranchRequestQueue private constructor(private val context: Context) {
             BranchLogger.w("STUCK_LOCK_RESOLUTION: Forcing removal of stuck INSTALL_REFERRER_FETCH_WAIT_LOCK")
             request.removeProcessWaitLock(ServerRequest.PROCESS_WAIT_LOCK.INSTALL_REFERRER_FETCH_WAIT_LOCK)
         }
+
+        // EMT-3860: the intent-pending lock is live again. If onActivityResumed / onIntentReady
+        // never fires (e.g. a headless cold start), force-resolve it after the stuck window so the
+        // init request is not held for the full 30s timeout.
+        if (waitLocks.contains("INTENT_PENDING_WAIT_LOCK")) {
+            BranchLogger.w("STUCK_LOCK_RESOLUTION: Forcing removal of stuck INTENT_PENDING_WAIT_LOCK")
+            request.removeProcessWaitLock(ServerRequest.PROCESS_WAIT_LOCK.INTENT_PENDING_WAIT_LOCK)
+        }
     }
     
     /**

--- a/Branch-SDK/src/test/java/io/branch/referral/BranchRequestQueueIntentLockTest.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/BranchRequestQueueIntentLockTest.kt
@@ -1,0 +1,47 @@
+package io.branch.referral
+
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.robolectric.RuntimeEnvironment
+import java.lang.reflect.Method
+
+/**
+ * EMT-3860 backstop: once the INTENT_PENDING_WAIT_LOCK becomes live again, a request stuck on it
+ * must be force-resolved by tryResolveStuckLocks after the 10s window — otherwise (with the
+ * EMT-3859 fix removing the ~500ms ceiling) a cold start where onActivityResumed never fires would
+ * hold the init request for the full 30s. Exercises the production tryResolveStuckLocks directly.
+ */
+class BranchRequestQueueIntentLockTest : BranchTestBase() {
+
+    private lateinit var queue: BranchRequestQueue
+    private lateinit var tryResolveStuckLocks: Method
+
+    @Before
+    fun setUp() {
+        super.setUpBase()
+        queue = BranchRequestQueue.getInstance(RuntimeEnvironment.getApplication())
+        tryResolveStuckLocks = BranchRequestQueue::class.java.getDeclaredMethod(
+            "tryResolveStuckLocks",
+            ServerRequest::class.java,
+            String::class.java
+        ).apply { isAccessible = true }
+    }
+
+    @Test
+    fun stuckIntentPendingLock_isForceRemoved() {
+        val request = mock(ServerRequest::class.java)
+        tryResolveStuckLocks.invoke(queue, request, "INTENT_PENDING_WAIT_LOCK")
+        verify(request).removeProcessWaitLock(ServerRequest.PROCESS_WAIT_LOCK.INTENT_PENDING_WAIT_LOCK)
+    }
+
+    @Test
+    fun unrelatedLock_doesNotRemoveIntentPending() {
+        val request = mock(ServerRequest::class.java)
+        tryResolveStuckLocks.invoke(queue, request, "GAID_FETCH_WAIT_LOCK")
+        verify(request, never())
+            .removeProcessWaitLock(ServerRequest.PROCESS_WAIT_LOCK.INTENT_PENDING_WAIT_LOCK)
+    }
+}


### PR DESCRIPTION
On a cold start, a Branch deep link click returned `+clicked_branch_link=false` and dropped attribution: the install/open request fired before the launch intent was parsed, so it went out without `external_intent_uri`.

This restores the intent-pending wait lock that 5.x had. The init request is held until `onIntentReady` has read and stripped the launch-intent params, then released, so the request carries the link data. `onIntentReady` is reordered to read params before unlocking, and the queue's stuck-lock resolver gets an `INTENT_PENDING` arm so the lock can't wedge the queue.

Verified: `BranchRequestQueueIntentLockTest` covers the stuck-lock resolution; full unit module green. The fix was also validated end-to-end on a real emulator (the install POST carries `external_intent_uri` after a cold-start click) — that instrumented test lands as a follow-up once the androidTest harness (EMT-3874 + EMT-3875) is in, since it needs both to compile and run.

Merge order: independent of the other beta fixes; base `6.0.0-beta.0`.
