### PR TITLE
EMT-3862 -- Show IntegrationValidator on first launch by waiting for the session

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/validators/IntegrationValidator.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/validators/IntegrationValidator.java
@@ -1,19 +1,28 @@
 package io.branch.referral.validators;
 
 import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 import android.view.WindowManager;
 
 import org.json.JSONObject;
 
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.branch.interfaces.IBranchLoggingCallbacks;
 import io.branch.referral.Branch;
+import io.branch.referral.BranchSessionState;
+import io.branch.referral.BranchSessionStateListener;
 
 public class IntegrationValidator implements ServerRequestGetAppConfig.IGetAppConfigEvents {
 
     private static IntegrationValidator instance;
+
+    /** EMT-3862: max time the validator waits for session init before surfacing a config-unavailable diagnostic. */
+    private static final long SESSION_INIT_WAIT_MS = 10_000L;
+
     private final BranchIntegrationModel integrationModel;
     private final String TAG = "BranchSDK_Doctor";
     private final StringBuilder branchLogsStringBuilder;
@@ -52,13 +61,68 @@ public class IntegrationValidator implements ServerRequestGetAppConfig.IGetAppCo
         return instance.branchLogsStringBuilder.toString();
     }
 
-    private void validateSDKIntegration(Context context) {
+    private void validateSDKIntegration(final Context context) {
+        final Branch branch = Branch.getInstance();
+
+        // EMT-3862: ServerRequestGetAppConfig needs a session. On a first cold launch, with init
+        // still in flight, enqueuing it immediately fails it with ERR_NO_SESSION and the failure
+        // path (onAppConfigAvailable(null)) never shows the validator dialog. Defer the request
+        // until the session is initialized. Dev-only diagnostic; it does not change
+        // BranchRequestQueue failure semantics.
+        if (branch.canPerformOperations()) {
+            enqueueGetAppConfigRequest(context);
+            return;
+        }
+
+        // The validator exists to diagnose broken integrations, so it must NOT go silent if init
+        // fails or never completes. Resolve exactly once: enqueue on Initialized, otherwise surface
+        // the existing config-unavailable diagnostic on Failed or after a timeout. Always deregister
+        // the observer so it cannot leak the Context held by this validator.
+        final AtomicBoolean resolved = new AtomicBoolean(false);
+        final Handler handler = new Handler(Looper.getMainLooper());
+        final BranchSessionStateListener[] observerRef = new BranchSessionStateListener[1];
+
+        final Runnable onTimeout = new Runnable() {
+            @Override
+            public void run() {
+                if (resolved.compareAndSet(false, true)) {
+                    branch.removeSessionStateObserver(observerRef[0]);
+                    onAppConfigAvailable(null);
+                }
+            }
+        };
+
+        observerRef[0] = new BranchSessionStateListener() {
+            @Override
+            public void onSessionStateChanged(BranchSessionState previousState, BranchSessionState currentState) {
+                if (currentState instanceof BranchSessionState.Initialized) {
+                    if (resolved.compareAndSet(false, true)) {
+                        handler.removeCallbacks(onTimeout);
+                        branch.removeSessionStateObserver(this);
+                        enqueueGetAppConfigRequest(context);
+                    }
+                } else if (currentState instanceof BranchSessionState.Failed) {
+                    if (resolved.compareAndSet(false, true)) {
+                        handler.removeCallbacks(onTimeout);
+                        branch.removeSessionStateObserver(this);
+                        onAppConfigAvailable(null);
+                    }
+                }
+            }
+        };
+
+        branch.addSessionStateObserver(observerRef[0]);
+        handler.postDelayed(onTimeout, SESSION_INIT_WAIT_MS);
+    }
+
+    private void enqueueGetAppConfigRequest(Context context) {
         Branch.getInstance().requestQueue_.handleNewRequest(new ServerRequestGetAppConfig(context, IntegrationValidator.this));
     }
 
     private void doValidateWithAppConfig(JSONObject branchAppConfig) {
-        //retrieve the Branch dashboard configurations from the server
-        Branch.getInstance().requestQueue_.handleNewRequest(new ServerRequestGetAppConfig(context, this));
+        // EMT-3862: the dashboard config is already delivered by onAppConfigAvailable(branchAppConfig).
+        // The previous re-fetch here issued a redundant duplicate ServerRequestGetAppConfig and has
+        // been removed.
 
         logValidationProgress("\n\n------------------- Initiating Branch integration verification ---------------------------");
 


### PR DESCRIPTION
A beta tester reported the IntegrationValidator dialog never showed on the first launch after install, even with `validate()` in `onStart()`. It worked on every later launch.

The reason: `validateSDKIntegration` fired `ServerRequestGetAppConfig` immediately, before the session existed. On a cold first launch the request is failed with `ERR_NO_SESSION`, the failure path calls `onAppConfigAvailable(null)`, and the dialog never renders. On later launches the session is already there, so it works — which is exactly the "works the second time" symptom.

So I gate the request on session state: if the SDK can already operate, fetch now; otherwise wait for init to finish (a one-shot session-state observer) and fetch then. This is validator-side only — it does not touch `BranchRequestQueue` semantics.

One thing worth hardening: a *diagnostic* must not go silent on a broken integration, which is precisely who needs it. So if init fails or never completes, I still surface the existing "couldn't read config" diagnostic (and always deregister the observer so it can't leak the Context). I also dropped a duplicate `GetAppConfig` request that the old code fired on the callback.

Verified: compiles, full unit module green (414/0). First-launch render will be confirmed on the rehabilitated instrumented harness (EMT-3875).

Heads-up for reviewers: `BranchSessionStateManager.listeners` is a plain list even though it imports (unused) `CopyOnWriteArrayList` and claims thread-safety. The remove-from-callback here is safe (main thread + snapshot iteration), but that list should become the `CopyOnWriteArrayList` it already imports. Pre-existing, out of scope here.

Merge order: independent of the others; base `6.0.0-beta.0`.
