### PR TITLE
EMT-3863 -- Restore a deprecated source-compat alias for the relocated LATD listener

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -2585,7 +2585,7 @@ public class Branch {
      * saved via PreferenceHelper.setLATDAttributionWindow(). If no value has been saved, Branch
      * defaults to a 30 day attribution window (SDK sends -1 to request the default from the server).
      *
-     * @param callback An instance of {@link io.branch.referral.ServerRequestGetLATD.BranchLastAttributedTouchDataListener}
+     * @param callback An instance of {@link io.branch.referral.Branch.BranchLastAttributedTouchDataListener}
      *                 to callback with last attributed touch data
      *
      */
@@ -2598,7 +2598,7 @@ public class Branch {
     /**
      * Gets the available last attributed touch data with a custom set attribution window.
      *
-     * @param callback An instance of {@link io.branch.referral.ServerRequestGetLATD.BranchLastAttributedTouchDataListener}
+     * @param callback An instance of {@link io.branch.referral.Branch.BranchLastAttributedTouchDataListener}
      *                to callback with last attributed touch data
      * @param attributionWindow An {@link int} to bound the the window of time in days during which
      *                          the attribution data is considered valid. Note that, server side, the

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestGetLATD.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestGetLATD.java
@@ -7,6 +7,18 @@ import org.json.JSONObject;
 
 public class ServerRequestGetLATD extends ServerRequest {
 
+    /**
+     * @deprecated This listener moved to {@link Branch.BranchLastAttributedTouchDataListener}. This
+     * alias is kept only for source compatibility with 5.x integrations that implemented the nested
+     * {@code ServerRequestGetLATD.BranchLastAttributedTouchDataListener}; it is <b>not</b> binary
+     * compatible, so a prebuilt app must be recompiled. Use {@link Branch.BranchLastAttributedTouchDataListener}
+     * directly in new code.
+     */
+    @Deprecated
+    public interface BranchLastAttributedTouchDataListener
+            extends Branch.BranchLastAttributedTouchDataListener {
+    }
+
     // defaultAttributionWindow is the "default" for the SDK's side, server interprets it as 30 days
     protected static final int defaultAttributionWindow = -1;
     private int attributionWindow;

--- a/Branch-SDK/src/test/java/io/branch/referral/LatdListenerApiCompatTest.java
+++ b/Branch-SDK/src/test/java/io/branch/referral/LatdListenerApiCompatTest.java
@@ -1,0 +1,46 @@
+package io.branch.referral;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * EMT-3863: 5.x source implemented the LATD callback via the nested
+ * ServerRequestGetLATD.BranchLastAttributedTouchDataListener. The beta moved it to
+ * Branch.BranchLastAttributedTouchDataListener with no alias at the old location, so that source
+ * stopped compiling on upgrade (reported by Ana, 5.16.3 -> beta). This pins source compatibility:
+ * the old nested type still resolves, is usable exactly as Ana wrote it, and is @Deprecated.
+ *
+ * The anonymous implementation below is the compile-time proof — it only builds when the alias
+ * exists, which is precisely the acceptance criterion.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class LatdListenerApiCompatTest {
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void oldNestedListenerIsSourceCompatible() {
+        // Ana's 5.x code, verbatim shape.
+        ServerRequestGetLATD.BranchLastAttributedTouchDataListener legacyListener =
+                new ServerRequestGetLATD.BranchLastAttributedTouchDataListener() {
+                    @Override
+                    public void onDataFetched(JSONObject jsonObject, BranchError error) {
+                        // no-op
+                    }
+                };
+        // The alias must satisfy the relocated callsite type with no cast.
+        Branch.BranchLastAttributedTouchDataListener asNewType = legacyListener;
+        assertNotNull(asNewType);
+    }
+
+    @Test
+    public void oldNestedListenerIsDeprecated() {
+        assertTrue("the restored alias must be @Deprecated so upgraders are nudged to the new type",
+                ServerRequestGetLATD.BranchLastAttributedTouchDataListener.class
+                        .isAnnotationPresent(Deprecated.class));
+    }
+}


### PR DESCRIPTION
A beta tester hit a compile break upgrading 5.16.3 to the beta: the 6.0 refactor moved the nested `ServerRequestGetLATD.BranchLastAttributedTouchDataListener` to `Branch.BranchLastAttributedTouchDataListener` and left nothing at the old location, so their `new ServerRequestGetLATD.BranchLastAttributedTouchDataListener(){...}` stopped compiling.

The move itself is correct — that listener never belonged on an internal request class — so I keep it and re-add the old nested type as a `@Deprecated` alias that extends the new one. Same single method (`onDataFetched`), so existing anonymous implementations satisfy the relocated callsites with no cast. I also repointed the two `getLastAttributedTouchData` javadoc `@param` links, which still named the old location.

This restores **source** compatibility only. A prebuilt app that isn't recompiled would still hit `NoSuchMethodError`, because the callsite's method descriptor changed when the parameter type moved — the javadoc states this. One caveat worth calling out for integrators: the alias emits a deprecation warning, so a team building with `-Werror` / warnings-as-errors must suppress it or migrate to `Branch.BranchLastAttributedTouchDataListener`.

Test compiles the reported 5.x usage and asserts `@Deprecated`: RED (compile error "cannot find symbol") before, GREEN after. Full unit module green (414/0).

Merge order: independent of the other beta fixes; base `6.0.0-beta.0`.
