### PR TITLE
EMT-3861 -- Restore the no-argument Branch.logout() overload

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -1011,6 +1011,15 @@ public class Branch {
      * <p>This method should be called if you know that a different person is about to use the app. For example,
      * if you allow users to log out and let their friend use the app, you should call this to notify Branch
      * to create a new user for this device. This will clear the first and latest params, as a new session is created.</p>
+     */
+    public void logout() {
+        logout(null);
+    }
+
+    /**
+     * <p>This method should be called if you know that a different person is about to use the app. For example,
+     * if you allow users to log out and let their friend use the app, you should call this to notify Branch
+     * to create a new user for this device. This will clear the first and latest params, as a new session is created.</p>
      *
      * @param callback An instance of {@link io.branch.referral.Branch.LogoutStatusListener} to callback with the logout operation status.
      */

--- a/Branch-SDK/src/test/java/io/branch/referral/LogoutApiCompatTest.java
+++ b/Branch-SDK/src/test/java/io/branch/referral/LogoutApiCompatTest.java
@@ -1,0 +1,30 @@
+package io.branch.referral;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.lang.reflect.Method;
+
+/**
+ * EMT-3861: the no-argument Branch.logout() overload that 5.x exposed was dropped in the beta, so
+ * the very common branch.logout() call no longer compiles for upgraders. These checks pin the
+ * public contract: the no-arg overload exists again, and the callback overload is left untouched.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class LogoutApiCompatTest {
+
+    @Test
+    public void noArgLogoutOverloadExists() throws NoSuchMethodException {
+        Method logout = Branch.class.getMethod("logout");
+        assertEquals("logout() must return void", void.class, logout.getReturnType());
+    }
+
+    @Test
+    public void callbackLogoutOverloadUnchanged() throws NoSuchMethodException {
+        Method logout = Branch.class.getMethod("logout", Branch.LogoutStatusListener.class);
+        assertEquals("logout(LogoutStatusListener) must remain", void.class, logout.getReturnType());
+    }
+}


### PR DESCRIPTION
A beta tester flagged that `branch.logout()` no longer compiles — the beta exposes only `logout(LogoutStatusListener)`. 5.x shipped both, with the no-arg form delegating (`logout(){ logout(null); }`); it was dropped during the EMT-2260 queue cleanup, and since the behavior it provided still exists, the removal looks accidental.

I restore exactly that overload. It's behavior-neutral: `QueueOperationLogout` types its callback as nullable and guards every dereference, so `logout(null)` is safe, and there's no overload ambiguity (distinct arity).

Test is a reflection check that `logout()` exists and `logout(LogoutStatusListener)` is unchanged: RED (`NoSuchMethodException`) before, GREEN after. Full unit module green (414/0).

Merge order: independent of the other beta fixes; base `6.0.0-beta.0`.
