### PR TITLE
SDK-2463 -- Proposed Solution: Skip the Open on configuration-change activity recreation

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/observers/BranchOpenObserver.kt
+++ b/Branch-SDK/src/main/java/io/branch/observers/BranchOpenObserver.kt
@@ -11,13 +11,25 @@ internal class BranchOpenObserver(private val branchInstance: Branch) : Applicat
 
     private var activityCount = 0
 
+    // SDK-2463: set when the last visible activity stops because it is being recreated for a
+    // configuration change (folding/unfolding a foldable, rotation, etc.). It tells the matching
+    // onActivityStarted that the foreground->foreground recreation is not a real app open.
+    private var recreatingForConfigChange = false
+
     override fun onActivityStarted(activity: Activity) {
         activityCount++
         BranchLogger.v("BranchOpenObserver onActivityStarted: $activity activityCount incremented to: $activityCount")
 
         if (activityCount == 1) {
-            branchInstance.sendOpen()
+            if (recreatingForConfigChange) {
+                // The single visible activity was just recreated for a configuration change; the app
+                // never left the foreground, so logging an Open here would be a spurious open.
+                BranchLogger.v("BranchOpenObserver skipping Open: activity recreated for a configuration change (SDK-2463)")
+            } else {
+                branchInstance.sendOpen()
+            }
         }
+        recreatingForConfigChange = false
     }
 
     override fun onActivityStopped(activity: Activity) {
@@ -26,6 +38,9 @@ internal class BranchOpenObserver(private val branchInstance: Branch) : Applicat
 
         if (activityCount <= 0) {
             activityCount = 0
+            // Remember whether this stop is a configuration-change recreation, so the immediately
+            // following onActivityStarted does not log a spurious Open.
+            recreatingForConfigChange = activity.isChangingConfigurations
         }
     }
 

--- a/Branch-SDK/src/test/java/io/branch/referral/BranchOpenObserverConfigChangeTest.java
+++ b/Branch-SDK/src/test/java/io/branch/referral/BranchOpenObserverConfigChangeTest.java
@@ -1,0 +1,52 @@
+package io.branch.referral;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.app.Activity;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * SDK-2463: BranchOpenObserver (the lifecycle observer actually registered in 6.0 via
+ * setActivityLifeCycleObserver) logs an Open whenever the visible-activity count goes 0 -> 1. A
+ * configuration change (folding/unfolding a foldable, rotation) destroys and recreates the
+ * foregrounded activity, so the count momentarily hits 0 and the recreated activity logs a spurious
+ * Open. The observer must skip the Open when the 0 -> 1 transition is a configuration-change
+ * recreation, and still fire it on a real foreground.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class BranchOpenObserverConfigChangeTest {
+
+    @Test
+    public void configChangeRecreation_doesNotSendSecondOpen() {
+        Branch branch = mock(Branch.class);
+        Activity activity = mock(Activity.class);
+        BranchOpenObserver observer = new BranchOpenObserver(branch);
+
+        observer.onActivityStarted(activity);            // count 0 -> 1: initial open
+        when(activity.isChangingConfigurations()).thenReturn(true);
+        observer.onActivityStopped(activity);            // count 1 -> 0: config-change recreation
+        observer.onActivityStarted(activity);            // count 0 -> 1 again: must NOT open
+
+        verify(branch, times(1)).sendOpen();
+    }
+
+    @Test
+    public void realBackgroundThenForeground_sendsSecondOpen() {
+        Branch branch = mock(Branch.class);
+        Activity activity = mock(Activity.class);
+        when(activity.isChangingConfigurations()).thenReturn(false);
+        BranchOpenObserver observer = new BranchOpenObserver(branch);
+
+        observer.onActivityStarted(activity);            // open #1
+        observer.onActivityStopped(activity);            // real background
+        observer.onActivityStarted(activity);            // real foreground: open #2
+
+        verify(branch, times(2)).sendOpen();
+    }
+}


### PR DESCRIPTION
Folding/unfolding a foldable logs a spurious `Open` even though the app never leaves the foreground. Same thing happens on rotation: any configuration change that recreates the foregrounded activity destroys + recreates it, so the visible-activity count momentarily hits 0 and the recreated activity logs an Open.

`BranchOpenObserver` (the observer registered in 6.0) fires `sendOpen()` whenever the count goes 0 → 1. The fix records, on the count → 0 stop, whether the activity is being destroyed for a configuration change (`activity.isChangingConfigurations`), and skips `sendOpen()` on the matching 0 → 1 start. Real foregrounds still fire the Open. This mirrors how AndroidX `ProcessLifecycleOwner` uses `isChangingConfigurations()` in `onStop` to avoid emitting an event on a config-change recreation.

A note on how I got here: I first patched `BranchActivityLifecycleObserver`, but an adversarial review caught that that class isn't the one registered in 6.0 — `setActivityLifeCycleObserver` registers `BranchOpenObserver`. Verified with a grep before redoing the fix on the live observer. Worth knowing for reviewers.

**Scope — this is also on 5.x, but via a different mechanism.** `master` registers `BranchActivityLifecycleObserver`, which *closes the session* on count 0 and re-opens on the recreated resume (a different code path). That needs its own guard on `closeSessionInternal()`; I have that draft ready. This PR fixes the 6.0 `BranchOpenObserver` path only — the 5.x patch should be a separate ticket/PR.

Heads-up for reviewers:
- This shifts Open/session counts on foldable- and rotation-heavy cohorts (it stops the spurious churn). Correct behavior, but worth a line in the 6.0 changelog since it's a measurable change for customers.
- Known edge: if a config-change recreation never restarts the activity (app backgrounded mid-recreate), the flag could suppress one later Open. Rare — config-change recreations complete in the same loop.

Tests: a config-change recreation fires no second Open; a real background → foreground still does (RED with the guard removed, GREEN after). Full unit module green.

Merge order: independent; base `6.0.0-alpha.1`.