### PR TITLE
EMT-3869 -- Report a timeout-specific error instead of ERR_NO_SESSION on lock-wait timeout

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/BranchRequestQueue.kt
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchRequestQueue.kt
@@ -391,21 +391,23 @@ class BranchRequestQueue private constructor(private val context: Context) {
     ) {
         // EMT-3859: a lock-waiting request can only reach failure through the timeout arm, so
         // never attribute its failure to the retry limit.
-        val errorMessage = when {
+        // EMT-3869: report a timeout-specific error for the timeout arm so callers can tell a
+        // process-lock-wait timeout apart from a genuinely missing session.
+        val (errorCode, errorMessage) = when {
             !isWaitingOnLock && retryInfo.hasExceededRetryLimit(MAX_RETRY_ATTEMPTS) ->
-                "Request exceeded maximum retry attempts (${MAX_RETRY_ATTEMPTS})"
+                BranchError.ERR_NO_SESSION to "Request exceeded maximum retry attempts (${MAX_RETRY_ATTEMPTS})"
             retryInfo.hasExceededTimeout(REQUEST_TIMEOUT_MS) ->
-                "Request exceeded timeout (${REQUEST_TIMEOUT_MS}ms)"
-            else -> "Request failed unknown reason"
+                BranchError.ERR_BRANCH_REQ_TIMED_OUT to "Request exceeded timeout (${REQUEST_TIMEOUT_MS}ms)"
+            else -> BranchError.ERR_NO_SESSION to "Request failed unknown reason"
         }
-        
+
         BranchLogger.d("DEBUG: $errorMessage for request: ${request::class.simpleName}")
-        
+
         // Clean up retry tracking
         requestRetryInfo.remove(requestId)
-        
+
         // Fail the request
-        request.handleFailure(BranchError.ERR_NO_SESSION, errorMessage)
+        request.handleFailure(errorCode, errorMessage)
     }
     
     /**

--- a/Branch-SDK/src/test/java/io/branch/referral/RequestTimeoutErrorTest.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/RequestTimeoutErrorTest.kt
@@ -1,0 +1,73 @@
+package io.branch.referral
+
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.robolectric.RuntimeEnvironment
+import java.lang.reflect.Constructor
+import java.lang.reflect.Method
+
+/**
+ * EMT-3869: when the modern [BranchRequestQueue] fails a request because it exceeded the
+ * process-lock-wait timeout, it must report a timeout-specific error
+ * ([BranchError.ERR_BRANCH_REQ_TIMED_OUT]), not [BranchError.ERR_NO_SESSION], so callers can tell a
+ * real timeout apart from a genuinely missing session. A retry-limit failure still uses
+ * ERR_NO_SESSION.
+ *
+ * Drives the production handleRequestFailureWithCleanup directly via reflection — no Android
+ * framework or network — so the result is deterministic.
+ */
+class RequestTimeoutErrorTest : BranchTestBase() {
+
+    private lateinit var queue: BranchRequestQueue
+    private lateinit var retryInfoClass: Class<*>
+    private lateinit var retryInfoCtor: Constructor<*>
+    private lateinit var handleFailure: Method
+
+    @Before
+    fun setUp() {
+        super.setUpBase()
+        queue = BranchRequestQueue.getInstance(RuntimeEnvironment.getApplication())
+
+        retryInfoClass = Class.forName("io.branch.referral.RequestRetryInfo")
+        retryInfoCtor = retryInfoClass.getDeclaredConstructor(
+            String::class.java,
+            Long::class.javaPrimitiveType,   // firstAttemptTime
+            Int::class.javaPrimitiveType,    // retryCount
+            Long::class.javaPrimitiveType,   // lastAttemptTime
+            Long::class.javaPrimitiveType    // firstWaitLockTime
+        ).apply { isAccessible = true }
+
+        handleFailure = BranchRequestQueue::class.java.getDeclaredMethod(
+            "handleRequestFailureWithCleanup",
+            ServerRequest::class.java,
+            String::class.java,
+            retryInfoClass,
+            Boolean::class.javaPrimitiveType
+        ).apply { isAccessible = true }
+    }
+
+    private fun retryInfo(retryCount: Int, firstAttemptAgeMs: Long): Any {
+        val now = System.currentTimeMillis()
+        return retryInfoCtor.newInstance("test-req", now - firstAttemptAgeMs, retryCount, now, 0L)
+    }
+
+    @Test
+    fun timeoutFailure_reportsTimeoutSpecificError() {
+        val request = mock(ServerRequest::class.java)
+        // Exceeded the 30s timeout, and waiting on a lock so it reaches the timeout arm.
+        handleFailure.invoke(queue, request, "test-req", retryInfo(retryCount = 1, firstAttemptAgeMs = 31_000), true)
+        verify(request).handleFailure(eq(BranchError.ERR_BRANCH_REQ_TIMED_OUT), anyString())
+    }
+
+    @Test
+    fun retryLimitFailure_keepsNoSessionError() {
+        val request = mock(ServerRequest::class.java)
+        // Exceeded the retry limit, not a timeout, not waiting on a lock.
+        handleFailure.invoke(queue, request, "test-req", retryInfo(retryCount = 99, firstAttemptAgeMs = 0), false)
+        verify(request).handleFailure(eq(BranchError.ERR_NO_SESSION), anyString())
+    }
+}


### PR DESCRIPTION
When the modern queue fails a request because it exceeded the process-lock-wait timeout, it reported `ERR_NO_SESSION` — which a caller can't tell apart from a genuinely missing session. The failure path already computed a timeout-specific *message*, but always passed `ERR_NO_SESSION` as the code.

Use the existing `BranchError.ERR_BRANCH_REQ_TIMED_OUT` (-111) for the timeout arm. Retry-limit and unknown failures keep `ERR_NO_SESSION`. No other behavior change.

Test drives `handleRequestFailureWithCleanup` directly via reflection: a timeout failure now reports `ERR_BRANCH_REQ_TIMED_OUT`, a retry-limit failure still reports `ERR_NO_SESSION` (RED before, GREEN after). Full unit module green.

**Base:** stacked on `fix/EMT-3859` — it modifies the same failure path (`handleRequestFailureWithCleanup` gained the `isWaitingOnLock` param there). Retarget this PR to `6.0.0-alpha.1` once EMT-3859 (#1352) merges.