### PR TITLE
SDK-2463 -- Guard against duplicate OPEN on foldable configuration changes

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/observers/BranchOpenObserver.kt
+++ b/Branch-SDK/src/main/java/io/branch/observers/BranchOpenObserver.kt
@@ -10,17 +10,23 @@ import android.os.Bundle
 internal class BranchOpenObserver(private val branchInstance: Branch) : Application.ActivityLifecycleCallbacks {
 
     private var activityCount = 0
+    private var isChangingConfiguration = false
 
     override fun onActivityStarted(activity: Activity) {
         activityCount++
         BranchLogger.v("BranchOpenObserver onActivityStarted: $activity activityCount incremented to: $activityCount")
 
-        if (activityCount == 1) {
+        if (activityCount == 1 && !isChangingConfiguration) {
             branchInstance.sendOpen()
         }
+        isChangingConfiguration = false
     }
 
     override fun onActivityStopped(activity: Activity) {
+        // A configuration change (e.g. folding/unfolding a foldable) destroys and recreates the
+        // foregrounded Activity. Remember it so the following onActivityStarted does not emit a
+        // duplicate OPEN for what is still the same session (SDK-2463).
+        isChangingConfiguration = activity.isChangingConfigurations
         activityCount--
         BranchLogger.v("BranchOpenObserver onActivityStopped: $activity activityCount decremented to: $activityCount")
 

--- a/Branch-SDK/src/test/java/io/branch/referral/BranchOpenObserverTest.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/BranchOpenObserverTest.kt
@@ -1,0 +1,56 @@
+package io.branch.referral
+
+import android.app.Activity
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+/**
+ * Unit tests for [BranchOpenObserver].
+ *
+ * Covers SDK-2463: folding/unfolding a foldable device triggers a configuration change that
+ * recreates the foregrounded Activity. The observer must not treat that recreation as a fresh
+ * foreground and emit a duplicate OPEN, while a genuine background-to-foreground still does.
+ */
+class BranchOpenObserverTest : BranchTestBase() {
+
+    private lateinit var branch: Branch
+    private lateinit var activity: Activity
+    private lateinit var observer: BranchOpenObserver
+
+    @Before
+    fun setUp() {
+        super.setUpBase()
+        branch = mock(Branch::class.java)
+        activity = mock(Activity::class.java)
+        observer = BranchOpenObserver(branch)
+    }
+
+    @Test
+    fun foldUnfoldWhileForegrounded_doesNotEmitDuplicateOpen() {
+        // App enters the foreground: exactly one OPEN.
+        observer.onActivityStarted(activity)
+
+        // Fold/unfold recreates the foregrounded Activity via a configuration change.
+        `when`(activity.isChangingConfigurations).thenReturn(true)
+        observer.onActivityStopped(activity)
+        observer.onActivityStarted(activity)
+
+        verify(branch, times(1)).sendOpen()
+    }
+
+    @Test
+    fun genuineBackgroundToForeground_emitsOpenAgain() {
+        observer.onActivityStarted(activity)
+
+        // Real background (not a configuration change), then return to foreground.
+        `when`(activity.isChangingConfigurations).thenReturn(false)
+        observer.onActivityStopped(activity)
+        observer.onActivityStarted(activity)
+
+        verify(branch, times(2)).sendOpen()
+    }
+}


### PR DESCRIPTION
## Why

On a foldable, folding or unfolding fires a configuration change that destroys and recreates the foregrounded Activity. The observer counts the stop/start as a fresh foreground and emits a second OPEN, even though the app never actually re-opened. This silently inflates open metrics for customers as foldables become more common.

## What

Track `Activity.isChangingConfigurations()` on stop and skip the OPEN on the immediately following start. A genuine background-to-foreground still emits OPEN.

## Test

Added a unit test on the observer:
- fold/unfold while foregrounded emits a single OPEN (fails without the guard)
- a real background-to-foreground emits OPEN again

## Scope

This is the minimal fix for the duplicate OPEN. Making the SDK fully fold-aware (dedicated Fold/Unfold events via WindowManager / FoldingFeature) is out of scope here.

## Notes

Only reproduces when the app lets the Activity be recreated on fold. Apps that declare screenSize/screenLayout in configChanges already avoid it.
