### PR TITLE
EMT-3882 -- Restore synchronous deep-link param getters

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -38,6 +38,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import io.branch.coroutines.RequestDeepLink;
 import io.branch.indexing.BranchUniversalObject;
@@ -1019,6 +1021,11 @@ public class Branch {
         requestQueue_.handleNewRequest(queueOperationLogout);
     }
 
+    private static final int LATCH_WAIT_UNTIL = 2500; // ms; the *Sync getters give up waiting after this.
+
+    CountDownLatch getFirstReferringParamsLatch = null;
+    CountDownLatch getLatestReferringParamsLatch = null;
+
     /**
      * <p>Returns the parameters associated with the link that referred the user. This is only set once,
      * the first time the user is referred by a link. Think of this as the user referral parameters.
@@ -1033,6 +1040,26 @@ public class Branch {
         String storedParam = prefHelper_.getInstallParams();
         JSONObject firstReferringParams = convertParamsStringToDictionary(storedParam);
         firstReferringParams = appendDebugParams(firstReferringParams);
+        return firstReferringParams;
+    }
+
+    /**
+     * <p>This function must be called from a non-UI thread! If Branch has no install link data
+     * yet, it blocks until the data is available, or until {@link #LATCH_WAIT_UNTIL} milliseconds
+     * elapse. Returns the same install-time referring parameters as {@link #getFirstReferringParams()}.</p>
+     *
+     * @return A {@link JSONObject} containing the install-time parameters as configured locally.
+     */
+    public JSONObject getFirstReferringParamsSync() {
+        getFirstReferringParamsLatch = new CountDownLatch(1);
+        if (prefHelper_.getInstallParams().equals(PrefHelper.NO_STRING_VALUE)) {
+            try {
+                getFirstReferringParamsLatch.await(LATCH_WAIT_UNTIL, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException ignored) {
+            }
+        }
+        JSONObject firstReferringParams = getFirstReferringParams();
+        getFirstReferringParamsLatch = null;
         return firstReferringParams;
     }
 
@@ -1066,6 +1093,27 @@ public class Branch {
         String storedParam = prefHelper_.getSessionParams();
         JSONObject latestParams = convertParamsStringToDictionary(storedParam);
         latestParams = appendDebugParams(latestParams);
+        return latestParams;
+    }
+
+    /**
+     * <p>This function must be called from a non-UI thread! If Branch has not been initialized
+     * yet, it blocks until initialization completes, or until {@link #LATCH_WAIT_UNTIL}
+     * milliseconds elapse. Returns the same latest referring parameters as
+     * {@link #getLatestReferringParams()}.</p>
+     *
+     * @return A {@link JSONObject} containing the latest referring parameters as configured locally.
+     */
+    public JSONObject getLatestReferringParamsSync() {
+        getLatestReferringParamsLatch = new CountDownLatch(1);
+        try {
+            if (!(getInitState() instanceof BranchSessionState.Initialized)) {
+                getLatestReferringParamsLatch.await(LATCH_WAIT_UNTIL, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException ignored) {
+        }
+        JSONObject latestParams = getLatestReferringParams();
+        getLatestReferringParamsLatch = null;
         return latestParams;
     }
     

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequestInitSession.java
@@ -87,7 +87,15 @@ public abstract class ServerRequestInitSession extends ServerRequest {
     protected void onInitSessionCompleted(ServerResponse response, Branch branch) {
         // Set the session state to INITIALISED after successful initialization
         branch.setInitState(BranchSessionState.Initialized.INSTANCE);
-        
+
+        // Release any callers blocked in getLatestReferringParamsSync / getFirstReferringParamsSync (EMT-3882).
+        if (branch.getLatestReferringParamsLatch != null) {
+            branch.getLatestReferringParamsLatch.countDown();
+        }
+        if (branch.getFirstReferringParamsLatch != null) {
+            branch.getFirstReferringParamsLatch.countDown();
+        }
+
         DeepLinkRoutingValidator.validate(branch.currentActivityReference_);
         branch.updateSkipURLFormats();
         BranchLogger.v("onInitSessionCompleted on thread " + Thread.currentThread().getName());

--- a/Branch-SDK/src/test/java/io/branch/referral/SyncReferringParamsApiTest.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/SyncReferringParamsApiTest.kt
@@ -1,0 +1,34 @@
+package io.branch.referral
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.reflect.Modifier
+
+/**
+ * API-surface tests for the restored synchronous deep-link parameter getters (EMT-3882).
+ *
+ * 5.x exposed getFirstReferringParamsSync() and getLatestReferringParamsSync(); the beta dropped
+ * them for async-only access. Product asked to keep a synchronous option, so both are restored.
+ * These tests pin the public contract (name, no-arg, returns JSONObject) and guard against the
+ * methods being removed again. Behavioral latch-release happens on the init flow.
+ */
+class SyncReferringParamsApiTest {
+
+    @Test
+    fun getFirstReferringParamsSync_isPublicNoArgReturningJsonObject() {
+        val method = Branch::class.java.getMethod("getFirstReferringParamsSync")
+        assertTrue("should be public", Modifier.isPublic(method.modifiers))
+        assertEquals("should return JSONObject", JSONObject::class.java, method.returnType)
+        assertEquals("should take no arguments", 0, method.parameterCount)
+    }
+
+    @Test
+    fun getLatestReferringParamsSync_isPublicNoArgReturningJsonObject() {
+        val method = Branch::class.java.getMethod("getLatestReferringParamsSync")
+        assertTrue("should be public", Modifier.isPublic(method.modifiers))
+        assertEquals("should return JSONObject", JSONObject::class.java, method.returnType)
+        assertEquals("should take no arguments", 0, method.parameterCount)
+    }
+}


### PR DESCRIPTION
## Why

5.x exposed `getFirstReferringParamsSync()` and `getLatestReferringParamsSync()`. The beta dropped them, leaving only async access (`requestDeepLinkData`). Both synchronous getters are restored so existing 5.x integrations keep working.

## What

- `getFirstReferringParamsSync()` and `getLatestReferringParamsSync()` restored with the 5.x latch semantics: block up to `LATCH_WAIT_UNTIL` (2500ms) for the data, then return the locally stored params.
- The latches are released from `ServerRequestInitSession.onInitSessionCompleted()`, the beta equivalent of the old queue's init-complete hook (5.x released them in `ServerRequestQueue`).
- Both delegate to the existing `getFirstReferringParams()` / `getLatestReferringParams()` for the actual read, so behavior matches the async getters once data is available.

## Test

`SyncReferringParamsApiTest` pins the public contract (both methods exist, public, no-arg, return `JSONObject`) and guards against the API being removed again. It fails with `NoSuchMethodException` without the restoration. Full `:Branch-SDK:testDebugUnitTest` is green.

Note on coverage: the suite mocks `Branch` everywhere and has no real-instance harness, so behavioral latch-release (block then release on init) is exercised by the init flow rather than a unit test.
