### PR TITLE
Android - Fix HashSet collection leading to crashes with EnableLogging

### DIFF
--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -15,6 +15,7 @@ import org.json.JSONObject;
 
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -91,7 +92,7 @@ public abstract class ServerRequest {
         requestPath_ = requestPath;
         params_ = post;
         prefHelper_ = PrefHelper.getInstance(context);
-        locks_ = new HashSet<>();
+        locks_ = Collections.synchronizedSet(new HashSet<>());
 
         creation_ts = System.currentTimeMillis();
         String creation_ts_date_formatted = formatUnixEpochToDateFormat(creation_ts);
@@ -776,7 +777,9 @@ public abstract class ServerRequest {
     }
 
     public String printWaitLocks(){
-        return Arrays.toString(locks_.toArray());
+        synchronized(locks_){
+            return Arrays.toString(locks_.toArray());
+        }
     }
     
     

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -762,9 +762,7 @@ public abstract class ServerRequest {
      */
     public void addProcessWaitLock(PROCESS_WAIT_LOCK lock) {
         if (lock != null) {
-            synchronized (locks_) {
-                locks_.add(lock);
-            }
+            locks_.add(lock);
         }
     }
     
@@ -774,14 +772,15 @@ public abstract class ServerRequest {
      * @param lock {@link PROCESS_WAIT_LOCK} type of lock
      */
     public void removeProcessWaitLock(PROCESS_WAIT_LOCK lock) {
-        synchronized (locks_) {
-            locks_.remove(lock);
-        }
+        locks_.remove(lock);
     }
 
     public String printWaitLocks() {
-        synchronized (locks_) {
+        try {
             return Arrays.toString(locks_.toArray());
+        } catch (ConcurrentModificationException e) {
+            BranchLogger.w("ConcurrentModificationException in printWaitLocks - queue modified during iteration.");
+            return "[concurrent-modification]";
         }
     }
     
@@ -792,9 +791,7 @@ public abstract class ServerRequest {
      * @return True if this request if any pre processing operation pending
      */
     public boolean isWaitingOnProcessToFinish() {
-        synchronized (locks_) {
-            return locks_.size() > 0;
-        }
+        return locks_.size() > 0;
     }
     
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/ServerRequest.java
@@ -15,7 +15,6 @@ import org.json.JSONObject;
 
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -92,7 +91,7 @@ public abstract class ServerRequest {
         requestPath_ = requestPath;
         params_ = post;
         prefHelper_ = PrefHelper.getInstance(context);
-        locks_ = Collections.synchronizedSet(new HashSet<>());
+        locks_ = new HashSet<>();
 
         creation_ts = System.currentTimeMillis();
         String creation_ts_date_formatted = formatUnixEpochToDateFormat(creation_ts);
@@ -763,7 +762,9 @@ public abstract class ServerRequest {
      */
     public void addProcessWaitLock(PROCESS_WAIT_LOCK lock) {
         if (lock != null) {
-            locks_.add(lock);
+            synchronized (locks_) {
+                locks_.add(lock);
+            }
         }
     }
     
@@ -773,11 +774,13 @@ public abstract class ServerRequest {
      * @param lock {@link PROCESS_WAIT_LOCK} type of lock
      */
     public void removeProcessWaitLock(PROCESS_WAIT_LOCK lock) {
-        locks_.remove(lock);
+        synchronized (locks_) {
+            locks_.remove(lock);
+        }
     }
 
-    public String printWaitLocks(){
-        synchronized(locks_){
+    public String printWaitLocks() {
+        synchronized (locks_) {
             return Arrays.toString(locks_.toArray());
         }
     }
@@ -789,7 +792,9 @@ public abstract class ServerRequest {
      * @return True if this request if any pre processing operation pending
      */
     public boolean isWaitingOnProcessToFinish() {
-        return locks_.size() > 0;
+        synchronized (locks_) {
+            return locks_.size() > 0;
+        }
     }
     
     /**


### PR DESCRIPTION
## Reference
EMT-3898 -- Android - Fix HashSet collection leading to crashes with EnableLogging

## Description
<!-- SUFFICIENT DESCRIPTION TO EXPLAIN THE PROBLEM THAT IS BEING SOLVED -->
Iterating the logs while processing the wait lock mechanisms is causing a race condition in which accessing the hashSet crashes the app. This fix synchronizes the checks to ensure that the threads do not conflict.

## Testing Instructions
<!-- TESTING INSTRUCTIONS -->

## Risk Assessment [`HIGH` || `MEDIUM` || `LOW`]
<!-- CHOOSE ONE OF THE THREE ASSESSMENTS ABOVE -->
<!-- FOR MEDIUM OR HIGH ASSESSMENTS, ADD ADDITIONAL NOTES HERE -->

- [ ] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
