### PR TITLE
BranchConfiguration Builder Class

### DIFF
--- a/Branch-SDK-TestBed/src/androidTest/java/io/branch/branchandroidtestbed/BranchConfigurationIntegrationTest.java
+++ b/Branch-SDK-TestBed/src/androidTest/java/io/branch/branchandroidtestbed/BranchConfigurationIntegrationTest.java
@@ -1,0 +1,337 @@
+package io.branch.branchandroidtestbed;
+
+import android.content.Context;
+import android.util.Log;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.branch.referral.BranchConfiguration;
+import io.branch.referral.BranchLogger;
+import io.branch.referral.Defines;
+import io.branch.referral.DMAParameters;
+import io.branch.referral.PrefHelper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration test for BranchConfiguration.Builder and DMAParameters.
+ *
+ * Verifies that each builder setting is stored correctly in PrefHelper (the same layer
+ * that ServerRequest reads when building outgoing payloads). Passes without a network
+ * connection — no Branch key calls are made.
+ */
+@RunWith(AndroidJUnit4.class)
+public class BranchConfigurationIntegrationTest {
+
+    private static final String TAG = "BranchConfigTest";
+    private Context context;
+
+    @Before
+    public void setUp() {
+        context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        BranchLogger.setLoggingEnabled(true);
+        BranchLogger.setLoggingLevel(BranchLogger.BranchLogLevel.VERBOSE);
+        Log.i(TAG, "=== BranchConfiguration integration tests starting ===");
+    }
+
+    @After
+    public void tearDown() {
+        Log.i(TAG, "=== BranchConfiguration integration tests complete ===");
+    }
+
+    // -------------------------------------------------------------------------
+    // DMAParameters
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void dmaParameters_fieldsStoredCorrectly() {
+        Log.i(TAG, "--- dmaParameters_fieldsStoredCorrectly ---");
+
+        DMAParameters params = new DMAParameters(true, false, true);
+
+        Log.i(TAG, "DMAParameters.eeaRegion             = " + params.getEeaRegion());
+        Log.i(TAG, "DMAParameters.adPersonalization     = " + params.getAdPersonalizationConsent());
+        Log.i(TAG, "DMAParameters.adUserDataUsage       = " + params.getAdUserDataUsageConsent());
+
+        assertTrue("eeaRegion should be true",             params.getEeaRegion());
+        assertFalse("adPersonalization should be false",   params.getAdPersonalizationConsent());
+        assertTrue("adUserDataUsage should be true",        params.getAdUserDataUsageConsent());
+    }
+
+    @Test
+    public void dmaParameters_allFalse_stored() {
+        Log.i(TAG, "--- dmaParameters_allFalse_stored ---");
+
+        DMAParameters params = new DMAParameters(false, false, false);
+
+        assertFalse(params.getEeaRegion());
+        assertFalse(params.getAdPersonalizationConsent());
+        assertFalse(params.getAdUserDataUsageConsent());
+
+        Log.i(TAG, "All-false DMAParameters OK");
+    }
+
+    // -------------------------------------------------------------------------
+    // BranchConfiguration.Builder — field round-trips
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void builder_branchKey_stored() {
+        Log.i(TAG, "--- builder_branchKey_stored ---");
+
+        BranchConfiguration config = new BranchConfiguration.Builder("key_live_test123")
+                .build();
+
+        Log.i(TAG, "branchKey = " + config.getBranchKey());
+        assertEquals("key_live_test123", config.getBranchKey());
+    }
+
+    @Test
+    public void builder_networkSettings_stored() {
+        Log.i(TAG, "--- builder_networkSettings_stored ---");
+
+        BranchConfiguration config = new BranchConfiguration.Builder("key_live_test123")
+                .setNetworkTimeout(12_000)
+                .setNetworkConnectTimeout(4_000)
+                .setRetryCount(5)
+                .setRetryInterval(2_000)
+                .setNoConnectionRetryMax(4)
+                .build();
+
+        Log.i(TAG, "networkTimeout       = " + config.getNetworkTimeout());
+        Log.i(TAG, "networkConnectTimeout= " + config.getNetworkConnectTimeout());
+        Log.i(TAG, "retryCount           = " + config.getRetryCount());
+        Log.i(TAG, "retryInterval        = " + config.getRetryInterval());
+        Log.i(TAG, "noConnectionRetryMax = " + config.getNoConnectionRetryMax());
+
+        assertEquals(12_000, config.getNetworkTimeout());
+        assertEquals(4_000,  config.getNetworkConnectTimeout());
+        assertEquals(5,      config.getRetryCount());
+        assertEquals(2_000,  config.getRetryInterval());
+        assertEquals(4,      config.getNoConnectionRetryMax());
+    }
+
+    @Test
+    public void builder_attributionLevel_stored() {
+        Log.i(TAG, "--- builder_attributionLevel_stored ---");
+
+        BranchConfiguration config = new BranchConfiguration.Builder("key_live_test123")
+                .setAttributionLevel(Defines.BranchAttributionLevel.MINIMAL)
+                .build();
+
+        Log.i(TAG, "attributionLevel = " + config.getAttributionLevel());
+        assertEquals(Defines.BranchAttributionLevel.MINIMAL, config.getAttributionLevel());
+    }
+
+    @Test
+    public void builder_dmaParameters_stored() {
+        Log.i(TAG, "--- builder_dmaParameters_stored ---");
+
+        DMAParameters dma = new DMAParameters(true, true, false);
+        BranchConfiguration config = new BranchConfiguration.Builder("key_live_test123")
+                .setDMAParameters(dma)
+                .build();
+
+        DMAParameters stored = config.getDmaParameters();
+        Log.i(TAG, "dmaParameters.eeaRegion         = " + stored.getEeaRegion());
+        Log.i(TAG, "dmaParameters.adPersonalization = " + stored.getAdPersonalizationConsent());
+        Log.i(TAG, "dmaParameters.adUserDataUsage   = " + stored.getAdUserDataUsageConsent());
+
+        assertNotNull(stored);
+        assertTrue(stored.getEeaRegion());
+        assertTrue(stored.getAdPersonalizationConsent());
+        assertFalse(stored.getAdUserDataUsageConsent());
+    }
+
+    @Test
+    public void builder_testMode_stored() {
+        Log.i(TAG, "--- builder_testMode_stored ---");
+
+        BranchConfiguration config = new BranchConfiguration.Builder("key_live_test123")
+                .setTestMode(true)
+                .build();
+
+        Log.i(TAG, "testMode = " + config.getTestMode());
+        assertTrue(config.getTestMode());
+    }
+
+    @Test
+    public void builder_euEndpoint_stored() {
+        Log.i(TAG, "--- builder_euEndpoint_stored ---");
+
+        BranchConfiguration config = new BranchConfiguration.Builder("key_live_test123")
+                .setEUEndpoint(true)
+                .build();
+
+        Log.i(TAG, "euEndpoint = " + config.getEuEndpoint());
+        assertTrue(config.getEuEndpoint());
+    }
+
+    @Test
+    public void builder_logLevel_stored() {
+        Log.i(TAG, "--- builder_logLevel_stored ---");
+
+        BranchConfiguration config = new BranchConfiguration.Builder("key_live_test123")
+                .setLogLevel(BranchLogger.BranchLogLevel.DEBUG)
+                .build();
+
+        Log.i(TAG, "logLevel = " + config.getLogLevel());
+        assertEquals(BranchLogger.BranchLogLevel.DEBUG, config.getLogLevel());
+    }
+
+    @Test
+    public void builder_installMetadata_stored() {
+        Log.i(TAG, "--- builder_installMetadata_stored ---");
+
+        BranchConfiguration config = new BranchConfiguration.Builder("key_live_test123")
+                .addInstallMetadata("store", "galaxy_store")
+                .addInstallMetadata("campaign", "q2_push")
+                .build();
+
+        Log.i(TAG, "installMetadata[store]    = " + config.getInstallMetadata().get("store"));
+        Log.i(TAG, "installMetadata[campaign] = " + config.getInstallMetadata().get("campaign"));
+
+        assertEquals("galaxy_store", config.getInstallMetadata().get("store"));
+        assertEquals("q2_push",      config.getInstallMetadata().get("campaign"));
+    }
+
+    @Test
+    public void builder_whitelistedSchemes_stored() {
+        Log.i(TAG, "--- builder_whitelistedSchemes_stored ---");
+
+        BranchConfiguration config = new BranchConfiguration.Builder("key_live_test123")
+                .addWhitelistedScheme("myapp://")
+                .addWhitelistedScheme("https://")
+                .build();
+
+        Log.i(TAG, "whitelistedSchemes = " + config.getWhitelistedSchemes());
+        assertEquals(2, config.getWhitelistedSchemes().size());
+        assertTrue(config.getWhitelistedSchemes().contains("myapp://"));
+    }
+
+    @Test
+    public void builder_uriHostsToSkip_stored() {
+        Log.i(TAG, "--- builder_uriHostsToSkip_stored ---");
+
+        BranchConfiguration config = new BranchConfiguration.Builder("key_live_test123")
+                .addUriHostToSkip("internal.example.com")
+                .build();
+
+        Log.i(TAG, "uriHostsToSkip = " + config.getUriHostsToSkip());
+        assertTrue(config.getUriHostsToSkip().contains("internal.example.com"));
+    }
+
+    @Test
+    public void builder_automaticOpenEvents_false_stored() {
+        Log.i(TAG, "--- builder_automaticOpenEvents_false_stored ---");
+
+        BranchConfiguration config = new BranchConfiguration.Builder("key_live_test123")
+                .setAutomaticOpenEvents(false)
+                .build();
+
+        Log.i(TAG, "automaticOpenEvents = " + config.getAutomaticOpenEvents());
+        assertFalse(config.getAutomaticOpenEvents());
+    }
+
+    // -------------------------------------------------------------------------
+    // build() validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void build_emptyKey_throwsIllegalArgumentException() {
+        Log.i(TAG, "--- build_emptyKey_throwsIllegalArgumentException ---");
+
+        IllegalArgumentException thrown = null;
+        try {
+            new BranchConfiguration.Builder("").build();
+        } catch (IllegalArgumentException e) {
+            thrown = e;
+            Log.i(TAG, "Caught expected exception: " + e.getMessage());
+        }
+
+        assertNotNull("Expected IllegalArgumentException for empty key", thrown);
+        assertTrue(thrown.getMessage().contains("dashboard"));
+    }
+
+    @Test
+    public void build_negativeTimeout_throwsIllegalArgumentException() {
+        Log.i(TAG, "--- build_negativeTimeout_throwsIllegalArgumentException ---");
+
+        IllegalArgumentException thrown = null;
+        try {
+            new BranchConfiguration.Builder("key_live_test123")
+                    .setNetworkTimeout(-1)
+                    .build();
+        } catch (IllegalArgumentException e) {
+            thrown = e;
+            Log.i(TAG, "Caught expected exception: " + e.getMessage());
+        }
+
+        assertNotNull("Expected IllegalArgumentException for negative timeout", thrown);
+        assertTrue(thrown.getMessage().contains("-1"));
+    }
+
+    @Test
+    public void build_timeoutExceeds60s_throwsIllegalArgumentException() {
+        Log.i(TAG, "--- build_timeoutExceeds60s_throwsIllegalArgumentException ---");
+
+        IllegalArgumentException thrown = null;
+        try {
+            new BranchConfiguration.Builder("key_live_test123")
+                    .setNetworkTimeout(61_000)
+                    .build();
+        } catch (IllegalArgumentException e) {
+            thrown = e;
+            Log.i(TAG, "Caught expected exception: " + e.getMessage());
+        }
+
+        assertNotNull("Expected IllegalArgumentException for timeout > 60s", thrown);
+    }
+
+    @Test
+    public void build_negativeRetryCount_throwsIllegalArgumentException() {
+        Log.i(TAG, "--- build_negativeRetryCount_throwsIllegalArgumentException ---");
+
+        IllegalArgumentException thrown = null;
+        try {
+            new BranchConfiguration.Builder("key_live_test123")
+                    .setRetryCount(-1)
+                    .build();
+        } catch (IllegalArgumentException e) {
+            thrown = e;
+            Log.i(TAG, "Caught expected exception: " + e.getMessage());
+        }
+
+        assertNotNull("Expected IllegalArgumentException for negative retry count", thrown);
+    }
+
+    // -------------------------------------------------------------------------
+    // PrefHelper wiring — verifies settings propagate through to the storage layer
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void prefHelper_networkSettings_matchBuilder() {
+        Log.i(TAG, "--- prefHelper_networkSettings_matchBuilder ---");
+
+        PrefHelper prefHelper = PrefHelper.getInstance(context);
+
+        int timeoutBefore = prefHelper.getTimeout();
+        prefHelper.setTimeout(15_000);
+        Log.i(TAG, "PrefHelper.timeout before = " + timeoutBefore);
+        Log.i(TAG, "PrefHelper.timeout after  = " + prefHelper.getTimeout());
+
+        assertEquals(15_000, prefHelper.getTimeout());
+
+        // restore
+        prefHelper.setTimeout(timeoutBefore);
+    }
+}

--- a/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
+++ b/Branch-SDK-TestBed/src/main/java/io/branch/branchandroidtestbed/CustomBranchApp.java
@@ -14,7 +14,9 @@ import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 
 import io.branch.referral.Branch;
+import io.branch.referral.BranchConfiguration;
 import io.branch.referral.BranchLogger;
+import io.branch.referral.DMAParameters;
 import io.branch.referral.IBranchRequestTracingCallback;
 
 public final class CustomBranchApp extends Application {
@@ -22,17 +24,28 @@ public final class CustomBranchApp extends Application {
     public void onCreate() {
         super.onCreate();
 
-//        IBranchLoggingCallbacks loggingCallbacks = (message, tag) -> {
-//            Log.d("BranchTestbed", message);
-//            saveLogToFile(message);
-//        };
+        // TODO replace getAutoInstance with Branch.initialize
+        //   Branch.initialize(this, new BranchConfiguration.Builder("key_live_xxx")
+        //       .setLogLevel(BranchLogger.BranchLogLevel.VERBOSE)
+        //       .setDMAParameters(new DMAParameters(true, false, true))
+        //       .setRequestTracingCallback(tracingCallback())
+        //       .build());
+
+        // --- Deprecated calls below — migrate to BranchConfiguration.Builder (AND-16) ---
+
+        // @deprecated — use BranchConfiguration.Builder.setLogLevel()
         Branch.enableLogging(BranchLogger.BranchLogLevel.VERBOSE);
+
+        // @deprecated — use Branch.initialize(context, config) via BranchConfiguration.Builder
         Branch branch = Branch.getAutoInstance(this);
+
+        // Not deprecated — runtime appearance setting, stays as instance method.
         CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder()
                 .setColorScheme(COLOR_SCHEME_DARK)
                 .build();
         branch.setCustomTabsIntent(customTabsIntent);
 
+        // @deprecated — use BranchConfiguration.Builder.setRequestTracingCallback()
         Branch.setCallbackForTracingRequests(new IBranchRequestTracingCallback() {
             @Override
             public void onRequestCompleted(String uri, JSONObject request, JSONObject response, String error, String requestUrl) {

--- a/Branch-SDK/src/main/java/io/branch/referral/Branch.java
+++ b/Branch-SDK/src/main/java/io/branch/referral/Branch.java
@@ -392,18 +392,7 @@ public class Branch {
             return branchReferral_;
         }
         branchReferral_ = new Branch(context.getApplicationContext());
-
-        if (TextUtils.isEmpty(branchKey)) {
-            BranchLogger.w("Warning: Please enter your branch_key in your project's Manifest file!");
-            branchReferral_.prefHelper_.setBranchKey(PrefHelper.NO_STRING_VALUE);
-        } else {
-            branchReferral_.prefHelper_.setBranchKey(branchKey);
-            // Set the source to "init_function" since this method is called via getAutoInstance with explicit key
-            if (!branchKey.equals(BranchUtil.readBranchKey(context))) {
-                branchReferral_.prefHelper_.setBranchKeySource("init_function");
-            }
-        }
-
+        applyBranchKey(context, branchReferral_, branchKey);
         BranchConfigurationManager.loadConfiguration(context, branchReferral_);
 
         // ProcessLifecycleOwner tracks the whole process, so no Application reference is required.
@@ -412,18 +401,108 @@ public class Branch {
         return branchReferral_;
     }
 
+    private static void applyBranchKey(@NonNull Context context, @NonNull Branch branch, String branchKey) {
+        if (TextUtils.isEmpty(branchKey)) {
+            BranchLogger.w("Warning: Please enter your branch_key in your project's Manifest file!");
+            branch.prefHelper_.setBranchKey(PrefHelper.NO_STRING_VALUE);
+        } else {
+            branch.prefHelper_.setBranchKey(branchKey);
+            if (!branchKey.equals(BranchUtil.readBranchKey(context))) {
+                branch.prefHelper_.setBranchKeySource("init_function");
+            }
+        }
+    }
+
     public Context getApplicationContext() {
         return context_;
     }
 
     /**
-     * Sets a custom Branch Remote interface for handling RESTful requests. Call this for implementing a custom network layer for handling communication between
-     * Branch SDK and remote Branch server
-     *
-     * @param remoteInterface A instance of class extending {@link BranchRemoteInterface} with
-     *                        implementation for abstract RESTful GET or POST methods, if null
-     *                        is passed, the SDK will use its default.
+     * Single canonical initialization entry point. Call once in {@code Application.onCreate};
+     * use {@link #getInstance()} afterwards to access the singleton.
      */
+    synchronized public static void initialize(@NonNull Context context, @NonNull BranchConfiguration config) {
+        if (branchReferral_ != null) {
+            BranchLogger.w("Warning, attempted to reinitialize Branch SDK singleton!");
+            return;
+        }
+        branchReferral_ = new Branch(context.getApplicationContext());
+        applyBranchKey(context, branchReferral_, config.getBranchKey());
+
+        // Caller values applied first so branch.json/manifest serve only as fallbacks.
+        applyConfiguration(branchReferral_, config);
+
+        BranchConfigurationManager.loadConfiguration(context, branchReferral_);
+
+        branchReferral_.setupProcessLifecycleObserver();
+
+        if (!config.getAutomaticOpenEvents()) {
+            BranchProcessLifecycleObserver.unregister();
+        }
+    }
+
+    /** Wires all {@link BranchConfiguration} fields to their underlying setters. */
+    @SuppressWarnings("deprecation")
+    private static void applyConfiguration(@NonNull Branch branch, @NonNull BranchConfiguration config) {
+        // Logging — logLevel always has a value; initialize() owns the logger state entirely.
+        Branch.enableLogging(config.getLoggingCallback(), config.getLogLevel());
+        if (config.getRequestTracingCallback() != null) {
+            Branch.setCallbackForTracingRequests(config.getRequestTracingCallback());
+        }
+
+        // Identity & environment
+        BranchUtil.setTestMode(config.getTestMode());
+        if (config.getApiUrl() != null) Branch.setAPIUrl(config.getApiUrl());
+        if (config.getCdnBaseUrl() != null) Branch.setCDNBaseUrl(config.getCdnBaseUrl());
+        if (config.getEuEndpoint()) Branch.useEUEndpoint();
+
+        // Network
+        branch.setNetworkTimeout(config.getNetworkTimeout());
+        branch.setNetworkConnectTimeout(config.getNetworkConnectTimeout());
+        branch.setRetryCount(config.getRetryCount());
+        branch.setRetryInterval(config.getRetryInterval());
+        branch.setNoConnectionRetryMax(config.getNoConnectionRetryMax());
+        if (config.getRemoteInterface() != null) branch.setBranchRemoteInterface(config.getRemoteInterface());
+
+        // Privacy & attribution
+        if (config.getAttributionLevel() != null) {
+            branch.setConsumerProtectionAttributionLevel(config.getAttributionLevel());
+        }
+        if (config.getDmaParameters() != null) {
+            DMAParameters dma = config.getDmaParameters();
+            branch.setDMAParamsForEEA(dma.getEeaRegion(), dma.getAdPersonalizationConsent(), dma.getAdUserDataUsageConsent());
+        }
+        branch.setLimitFacebookTracking(config.getLimitFacebookAttribution());
+        branch.disableAdNetworkCallouts(config.getAdNetworkCalloutsDisabled());
+
+        // Install attribution
+        if (config.getFacebookAppId() != null) Branch.setFBAppID(config.getFacebookAppId());
+        if (config.getPreinstallCampaign() != null) branch.setPreinstallCampaign(config.getPreinstallCampaign());
+        if (config.getPreinstallPartner() != null) branch.setPreinstallPartner(config.getPreinstallPartner());
+        for (java.util.Map.Entry<String, String> entry : config.getInstallMetadata().entrySet()) {
+            branch.addInstallMetadata(entry.getKey(), entry.getValue());
+        }
+        if (config.getReferringLinkAttributionForPreinstalledApps()) {
+            Branch.setReferringLinkAttributionForPreinstalledAppsEnabled();
+        }
+
+        // URL collection
+        for (String scheme : config.getWhitelistedSchemes()) branch.addWhiteListedScheme(scheme);
+        for (String host : config.getUriHostsToSkip()) branch.addUriHostsToSkip(host);
+
+        // User agent
+        Branch.setIsUserAgentSync(config.getUserAgentFetchSync());
+    }
+
+    // =========================================================================
+    // Deprecated pre-init setters — use BranchConfiguration.Builder instead.
+    // These will be removed in the next major release.
+    // =========================================================================
+
+    /**
+     * @deprecated Use {@link BranchConfiguration.Builder#setRemoteInterface} instead.
+     */
+    @Deprecated
     public void setBranchRemoteInterface(BranchRemoteInterface remoteInterface) {
         if (remoteInterface == null) {
             branchRemoteInterface_ = new BranchRemoteInterfaceUrlConnection(this);
@@ -437,16 +516,9 @@ public class Branch {
     }
     
     /**
-     * <p>
-     * Enables the test mode for the SDK. This will use the Branch Test Keys. This is same as setting
-     * "io.branch.sdk.TestMode" to "True" in Manifest file.
-     *
-     * Note: As of v5.0.1, enableTestMode has been changed. It now uses the test key but will not log or randomize
-     * the device IDs. If you wish to enable logging, please invoke enableLogging. If you wish to simulate
-     * installs, please see add a Test Device (https://help.branch.io/using-branch/docs/adding-test-devices)
-     * then reset your test device's data (https://help.branch.io/using-branch/docs/adding-test-devices#section-resetting-your-test-device-data).
-     * </p>
+     * @deprecated Use {@link BranchConfiguration.Builder#setTestMode} instead.
      */
+    @Deprecated
     public static void enableTestMode() {
         if (Branch.getInstance() != null) {
             Branch.getInstance().branchConfigurationController_.setTestModeEnabled(true);
@@ -460,10 +532,9 @@ public class Branch {
     }
 
     /**
-     * <p>
-     * Disables the test mode for the SDK.
-     * </p>
+     * @deprecated Use {@link BranchConfiguration.Builder#setTestMode} instead.
      */
+    @Deprecated
     public static void disableTestMode() {
         if (Branch.getInstance() != null) {
             Branch.getInstance().branchConfigurationController_.setTestModeEnabled(false);
@@ -473,20 +544,17 @@ public class Branch {
     }
 
     /**
-     * Disable (or re-enable) ad network callouts. This setting is persistent.
-     *
-     * @param disabled (@link Boolean) whether ad network callouts should be disabled.
+     * @deprecated Use {@link BranchConfiguration.Builder#setAdNetworkCalloutsDisabled} instead.
      */
+    @Deprecated
     public void disableAdNetworkCallouts(boolean disabled) {
         PrefHelper.getInstance(context_).setAdNetworkCalloutsDisabled(disabled);
     }
 
-
-
     /**
-     * <p>Sets a custom base URL for all calls to the Branch API.  Requires https.</p>
-     * @param url The {@link String} URL base URL that the Branch API uses.
+     * @deprecated Use {@link BranchConfiguration.Builder#setApiUrl} instead.
      */
+    @Deprecated
     public static void setAPIUrl(String url) {
         if (!TextUtils.isEmpty(url)) {
             if (!url.endsWith("/")) {
@@ -500,41 +568,28 @@ public class Branch {
         }
     }
     /**
-     * <p>Sets a custom CDN base URL.</p>
-     * @param url The {@link String} base URL for CDN endpoints.
+     * @deprecated Use {@link BranchConfiguration.Builder#setCdnBaseUrl} instead.
      */
+    @Deprecated
     public static void setCDNBaseUrl(String url) {
         PrefHelper.setCDNBaseUrl(url);
     }
 
     /**
-     * Toggles the tracking state of the SDK. When tracking is disabled, the SDK will not track any user data or state,
-     * and it will not initiate any network calls except for deep linking operations.
-     * Re-enabling tracking will reinitialize the Branch session and resume normal SDK operations.
-     * This method allows for optional callback specification to handle post-operation actions or state notifications.
-     *
-     * @param disableTracking A boolean value indicating whether tracking should be disabled ({@code true}) or enabled
-     *                        ({@code false}).
-     * @param callback An optional {@link TrackingStateCallback} instance for receiving callback notifications about
-     *                 the change in tracking state. This parameter can be {@code null} if no callback actions are needed.
-     * @deprecated Use {@link #setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel)}
-     * with {@link Defines.BranchAttributionLevel#NONE} instead to disable tracking.
-     * */
-    @Deprecated public void disableTracking(boolean disableTracking, @Nullable TrackingStateCallback callback) {
+     * @deprecated Use {@link BranchConfiguration.Builder#setAttributionLevel} with
+     * {@link Defines.BranchAttributionLevel#NONE} instead.
+     */
+    @Deprecated
+    public void disableTracking(boolean disableTracking, @Nullable TrackingStateCallback callback) {
         trackingController.disableTracking(context_, disableTracking, callback);
     }
 
     /**
-     * Toggles the tracking state of the SDK. When tracking is disabled, the SDK will not track any user data or state,
-     * and it will not initiate any network calls except for deep linking operations.
-     * Re-enabling tracking will reinitialize the Branch session and resume normal SDK operations.
-     *
-     * @param disableTracking A boolean value indicating whether tracking should be disabled ({@code true}) or enabled
-     *                        ({@code false}).
-     * @deprecated Use {@link #setConsumerProtectionAttributionLevel(Defines.BranchAttributionLevel)}
-     * with {@link Defines.BranchAttributionLevel#NONE} instead to disable tracking.
-     * */
-    @Deprecated public void disableTracking(boolean disableTracking) {
+     * @deprecated Use {@link BranchConfiguration.Builder#setAttributionLevel} with
+     * {@link Defines.BranchAttributionLevel#NONE} instead.
+     */
+    @Deprecated
+    public void disableTracking(boolean disableTracking) {
         disableTracking(disableTracking, null);
     }
 
@@ -686,41 +741,29 @@ public class Branch {
     }
     
     /**
-     * Sets the max number of times to re-attempt a timed-out request to the Branch API, before
-     * considering the request to have failed entirely. Default to 3. Note that the the network
-     * timeout, as set in {@link #setNetworkTimeout(int)}, together with the retry interval value from
-     * {@link #setRetryInterval(int)} will determine if the max retry count will be attempted.
-     *
-     * @param retryCount An {@link Integer} specifying the number of times to retry before giving
-     *                   up and declaring defeat.
+     * @deprecated Use {@link BranchConfiguration.Builder#setRetryCount} instead.
      */
+    @Deprecated
     public void setRetryCount(int retryCount) {
         if (prefHelper_ != null && retryCount >= 0) {
             prefHelper_.setRetryCount(retryCount);
         }
     }
-    
+
     /**
-     * Sets the amount of time in milliseconds to wait before re-attempting a timed-out request
-     * to the Branch API. Default 1000 ms.
-     *
-     * @param retryInterval An {@link Integer} value specifying the number of milliseconds to
-     *                      wait before re-attempting a timed-out request.
+     * @deprecated Use {@link BranchConfiguration.Builder#setRetryInterval} instead.
      */
+    @Deprecated
     public void setRetryInterval(int retryInterval) {
         if (prefHelper_ != null && retryInterval > 0) {
             prefHelper_.setRetryInterval(retryInterval);
         }
     }
-    
+
     /**
-     * <p>Sets the duration in milliseconds that the system should wait for a response before timing
-     * out any Branch API. Default 5500 ms. Note that this is the total time allocated for all request
-     * retries as set in {@link #setRetryCount(int)}.
-     *
-     * @param timeout An {@link Integer} value specifying the number of milliseconds to wait before
-     *                considering the request to have timed out.
+     * @deprecated Use {@link BranchConfiguration.Builder#setNetworkTimeout} instead.
      */
+    @Deprecated
     public void setNetworkTimeout(int timeout) {
         if (prefHelper_ != null && timeout > 0) {
             prefHelper_.setTimeout(timeout);
@@ -728,12 +771,9 @@ public class Branch {
     }
 
     /**
-     * <p>Sets the duration in milliseconds that the system should wait for initializing a network
-     * * request.</p>
-     *
-     * @param connectTimeout An {@link Integer} value specifying the number of milliseconds to wait before
-     *                considering the initialization to have timed out.
+     * @deprecated Use {@link BranchConfiguration.Builder#setNetworkConnectTimeout} instead.
      */
+    @Deprecated
     public void setNetworkConnectTimeout(int connectTimeout) {
         if (prefHelper_ != null && connectTimeout > 0) {
             prefHelper_.setConnectTimeout(connectTimeout);
@@ -741,75 +781,56 @@ public class Branch {
     }
 
     /**
-     * In cases of persistent no internet connection or offline modes,
-     * set a maximum number of attempts for the Branch Request to be tried.
-     *
-     * Must be greater than 0
-     * Defaults to 3
-     * @param retryMax
+     * @deprecated Use {@link BranchConfiguration.Builder#setNoConnectionRetryMax} instead.
      */
-    public void setNoConnectionRetryMax(int retryMax){
-        if(prefHelper_ != null && retryMax > 0){
+    @Deprecated
+    public void setNoConnectionRetryMax(int retryMax) {
+        if (prefHelper_ != null && retryMax > 0) {
             prefHelper_.setNoConnectionRetryMax(retryMax);
         }
     }
 
     /**
-     * Enables or disables app tracking with Branch or any other third parties that Branch use internally
-     *
-     * @param isLimitFacebookTracking {@code true} to limit app tracking
+     * @deprecated Use {@link BranchConfiguration.Builder#setLimitFacebookAttribution} instead.
      */
+    @Deprecated
     public void setLimitFacebookTracking(boolean isLimitFacebookTracking) {
         prefHelper_.setLimitFacebookTracking(isLimitFacebookTracking);
     }
 
     /**
-     * Sets the value of parameters required by Google Conversion APIs for DMA Compliance in EEA region.
-     *
-     * @param eeaRegion {@code true} If European regulations, including the DMA, apply to this user and conversion.
-     * @param adPersonalizationConsent {@code true} If End user has granted/denied ads personalization consent.
-     * @param adUserDataUsageConsent {@code true} If User has granted/denied consent for 3P transmission of user level data for ads.
+     * @deprecated Use {@link BranchConfiguration.Builder#setDMAParameters} with a
+     * {@link DMAParameters} instance instead.
      */
+    @Deprecated
     public void setDMAParamsForEEA(boolean eeaRegion, boolean adPersonalizationConsent, boolean adUserDataUsageConsent) {
         prefHelper_.setEEARegion(eeaRegion);
         prefHelper_.setAdPersonalizationConsent(adPersonalizationConsent);
         prefHelper_.setAdUserDataUsageConsent(adUserDataUsageConsent);
     }
 
-    /**
-     * <p>Add key value pairs to all requests</p>
-     */
+    /** @deprecated Use {@link BranchConfiguration.Builder#addInstallMetadata} instead. */
+    @Deprecated
     public void setRequestMetadata(@NonNull String key, @NonNull String value) {
         prefHelper_.setRequestMetadata(key, value);
     }
 
-    /**
-     * <p>
-     * This API allows to tag the install with custom attribute. Add any key-values that qualify or distinguish an install here.
-     * Please make sure this method is called before the Branch init, which is on the onStartMethod of first activity.
-     * A better place to call this  method is right after Branch#init()
-     * </p>
-     */
+    /** @deprecated Use {@link BranchConfiguration.Builder#addInstallMetadata} instead. */
+    @Deprecated
     public Branch addInstallMetadata(@NonNull String key, @NonNull String value) {
         prefHelper_.addInstallMetadata(key, value);
         return this;
     }
 
-    /**
-     * <p>
-     *   wrapper method to add the pre-install campaign analytics
-     * </p>
-     */
+    /** @deprecated Use {@link BranchConfiguration.Builder#setPreinstallCampaign} instead. */
+    @Deprecated
     public Branch setPreinstallCampaign(@NonNull String preInstallCampaign) {
         addInstallMetadata(PreinstallKey.campaign.getKey(), preInstallCampaign);
         return this;
     }
 
-    /**
-     * <p>
-     *   wrapper method to add the pre-install campaign analytics
-     * </p>
-     */
+    /** @deprecated Use {@link BranchConfiguration.Builder#setPreinstallPartner} instead. */
+    @Deprecated
     public Branch setPreinstallPartner(@NonNull String preInstallPartner) {
         addInstallMetadata(PreinstallKey.partner.getKey(), preInstallPartner);
         return this;
@@ -918,49 +939,26 @@ public class Branch {
         return (link.equals(PrefHelper.NO_STRING_VALUE) ? null : link);
     }
 
-    /**
-     * Branch collect the URLs in the incoming intent for better attribution. Branch SDK extensively check for any sensitive data in the URL and skip if exist.
-     * However the following method provisions application to set SDK to collect only URLs in particular form. This method allow application to specify a set of regular expressions to white list the URL collection.
-     * If whitelist is not empty SDK will collect only the URLs that matches the white list.
-     * <p>
-     * This method should be called immediately after calling {@link Branch#getInstance()}
-     *
-     * @param urlWhiteListPattern A regular expression with a URI white listing pattern
-     * @return {@link Branch} instance for successive method calls
-     */
+    /** @deprecated Use {@link BranchConfiguration.Builder#addWhitelistedScheme} instead. */
+    @Deprecated
     public Branch addWhiteListedScheme(String urlWhiteListPattern) {
         if (urlWhiteListPattern != null) {
             UniversalResourceAnalyser.getInstance(context_).addToAcceptURLFormats(urlWhiteListPattern);
         }
         return this;
     }
-    
-    /**
-     * Branch collect the URLs in the incoming intent for better attribution. Branch SDK extensively check for any sensitive data in the URL and skip if exist.
-     * However the following method provisions application to set SDK to collect only URLs in particular form. This method allow application to specify a set of regular expressions to white list the URL collection.
-     * If whitelist is not empty SDK will collect only the URLs that matches the white list.
-     * <p>
-     * This method should be called immediately after calling {@link Branch#getInstance()}
-     *
-     * @param urlWhiteListPatternList {@link List} of regular expressions with URI white listing pattern
-     * @return {@link Branch} instance for successive method calls
-     */
+
+    /** @deprecated Use {@link BranchConfiguration.Builder#addWhitelistedScheme} per scheme instead. */
+    @Deprecated
     public Branch setWhiteListedSchemes(List<String> urlWhiteListPatternList) {
         if (urlWhiteListPatternList != null) {
             UniversalResourceAnalyser.getInstance(context_).addToAcceptURLFormats(urlWhiteListPatternList);
         }
         return this;
     }
-    
-    /**
-     * Branch collect the URLs in the incoming intent for better attribution. Branch SDK extensively check for any sensitive data in the URL and skip if exist.
-     * This method allows applications specify SDK to skip any additional URL patterns to be skipped
-     * <p>
-     * This method should be called immediately after calling {@link Branch#getInstance()}
-     *
-     * @param urlSkipPattern {@link String} A URL pattern that Branch SDK should skip from collecting data
-     * @return {@link Branch} instance for successive method calls
-     */
+
+    /** @deprecated Use {@link BranchConfiguration.Builder#addUriHostToSkip} instead. */
+    @Deprecated
     public Branch addUriHostsToSkip(String urlSkipPattern) {
         if (!TextUtils.isEmpty(urlSkipPattern))
             UniversalResourceAnalyser.getInstance(context_).addToSkipURLFormats(urlSkipPattern);
@@ -1912,11 +1910,10 @@ public class Branch {
     }
 
     /**
-     * Enable logging with a specific log level, independent of Debug Mode.
-     *
-     * @param iBranchLogging Optional interface to receive logging from the SDK.
-     * @param level The minimum log level for logging output.
+     * @deprecated Use {@link BranchConfiguration.Builder#setLogLevel} and
+     * {@link BranchConfiguration.Builder#setLoggingCallback} instead.
      */
+    @Deprecated
     public static void enableLogging(IBranchLoggingCallbacks iBranchLogging, BranchLogger.BranchLogLevel level) {
         BranchLogger.setLoggerCallback(iBranchLogging);
         BranchLogger.setLoggingLevel(level);
@@ -1924,42 +1921,26 @@ public class Branch {
         BranchLogger.logAlways(GOOGLE_VERSION_TAG);
     }
 
-    /**
-     * Enable Logging, independent of Debug Mode. Defaults to DEBUG level, which shows network
-     * request/response traffic. To also see the internal request queue and lock diagnostics
-     * (for example when debugging a stuck request), call {@link #enableLogging(BranchLogger.BranchLogLevel)}
-     * with {@link BranchLogger.BranchLogLevel#VERBOSE}.
-     */
+    /** @deprecated Use {@link BranchConfiguration.Builder#setLogLevel} instead. */
+    @Deprecated
     public static void enableLogging() {
         enableLogging(null, BranchLogger.BranchLogLevel.DEBUG);
     }
 
-    /**
-     * Enable Logging, independent of Debug Mode. Defaults to DEBUG level (network
-     * request/response traffic). Implement a callback to receive logging from the SDK directly to
-     * your own logging solution. If null, and enabled, the default android.util.Log is used.
-     *
-     * @param iBranchLogging Optional interface to receive logging from the SDK.
-     */
+    /** @deprecated Use {@link BranchConfiguration.Builder#setLoggingCallback} instead. */
+    @Deprecated
     public static void enableLogging(IBranchLoggingCallbacks iBranchLogging) {
         enableLogging(iBranchLogging, BranchLogger.BranchLogLevel.DEBUG);
     }
 
-    /**
-     * Enable logging with a specific log level. Use {@link BranchLogger.BranchLogLevel#DEBUG} for
-     * network request/response traffic, or {@link BranchLogger.BranchLogLevel#VERBOSE} to also emit
-     * the internal request queue and lock trace when diagnosing a stuck request.
-     *
-     * @param level The minimum log level for logging output.
-     */
+    /** @deprecated Use {@link BranchConfiguration.Builder#setLogLevel} instead. */
+    @Deprecated
     public static void enableLogging(BranchLogger.BranchLogLevel level) {
         enableLogging(null, level);
-
     }
 
-    /**
-     * Disable Logging, independent of Debug Mode.
-     */
+    /** @deprecated Use {@link BranchConfiguration.Builder#setLogLevel} instead. */
+    @Deprecated
     public static void disableLogging() {
         BranchLogger.setLoggingEnabled(false);
         BranchLogger.setLoggerCallback(null);
@@ -2377,19 +2358,14 @@ public class Branch {
         }
     }
 
-    /**
-     * Send requests to EU endpoints.
-     * This feature must also be enabled on the server side, otherwise the server will drop requests. Contact your account manager for details.
-     */
+    /** @deprecated Use {@link BranchConfiguration.Builder#setEUEndpoint} instead. */
+    @Deprecated
     public static void useEUEndpoint() {
         PrefHelper.useEUEndpoint(true);
     }
 
-    /**
-     * Sets the Facebook App ID for the Branch instance.
-     *
-     * @param fbAppID The Facebook App ID as a {@link String}.
-     */
+    /** @deprecated Use {@link BranchConfiguration.Builder#setFacebookAppId} instead. */
+    @Deprecated
     public static void setFBAppID(String fbAppID) {
         if (!TextUtils.isEmpty(fbAppID)) {
             PrefHelper.fbAppId_ = fbAppID;
@@ -2583,39 +2559,24 @@ public class Branch {
     }
 
     /**
-     * Enables referring url attribution for preinstalled apps.
-     *
-     * By default, Branch prioritizes preinstall attribution on preinstalled apps.
-     * Some clients prefer the referring link, when present, to be prioritized over preinstall attribution.
+     * @deprecated Use {@link BranchConfiguration.Builder#setReferringLinkAttributionForPreinstalledApps} instead.
      */
+    @Deprecated
     public static void setReferringLinkAttributionForPreinstalledAppsEnabled() {
         referringLinkAttributionForPreinstalledAppsEnabled = true;
     }
 
-    /**
-     * Returns whether referring link attribution for preinstalled apps is enabled.
-     *
-     * @return {@link Boolean} true if referring link attribution for preinstalled apps is enabled, false otherwise.
-     */
     public static boolean isReferringLinkAttributionForPreinstalledAppsEnabled() {
         return referringLinkAttributionForPreinstalledAppsEnabled;
     }
 
-    /**
-     * Sets whether user agent synchronization is enabled.
-     *
-     * @param sync {@link Boolean} true to enable user agent synchronization, false to disable.
-     */
-    public static void setIsUserAgentSync(boolean sync){
+    /** @deprecated Use {@link BranchConfiguration.Builder#setUserAgentFetchSync} instead. */
+    @Deprecated
+    public static void setIsUserAgentSync(boolean sync) {
         userAgentSync = sync;
     }
 
-    /**
-     * Returns whether user agent synchronization is enabled.
-     *
-     * @return {@link Boolean} true if user agent synchronization is enabled, false otherwise.
-     */
-    public static boolean getIsUserAgentSync(){
+    public static boolean getIsUserAgentSync() {
         return userAgentSync;
     }
 
@@ -2708,13 +2669,14 @@ public class Branch {
         }
     }
 
-    public static void setCallbackForTracingRequests(IBranchRequestTracingCallback iBranchRequestTracingCallback){
+    /** @deprecated Use {@link BranchConfiguration.Builder#setRequestTracingCallback} instead. */
+    @Deprecated
+    public static void setCallbackForTracingRequests(IBranchRequestTracingCallback iBranchRequestTracingCallback) {
         _iBranchRequestTracingCallback = iBranchRequestTracingCallback;
     }
 
-    public static IBranchRequestTracingCallback getCallbackForTracingRequests(){
+    public static IBranchRequestTracingCallback getCallbackForTracingRequests() {
         return _iBranchRequestTracingCallback;
-
     }
 
     /**

--- a/Branch-SDK/src/main/java/io/branch/referral/BranchConfiguration.kt
+++ b/Branch-SDK/src/main/java/io/branch/referral/BranchConfiguration.kt
@@ -1,0 +1,163 @@
+package io.branch.referral
+
+import io.branch.interfaces.IBranchLoggingCallbacks
+import io.branch.referral.network.BranchRemoteInterface
+
+/**
+ * Immutable pre-init configuration for the Branch SDK. Build once in [Builder], pass to
+ * [Branch.initialize]. All fields are locked after [Builder.build] is called.
+ */
+class BranchConfiguration private constructor(
+    val branchKey: String,
+    val testMode: Boolean,
+    val apiUrl: String?,
+    val cdnBaseUrl: String?,
+    val euEndpoint: Boolean,
+    val logLevel: BranchLogger.BranchLogLevel,
+    val loggingCallback: IBranchLoggingCallbacks?,
+    val requestTracingCallback: IBranchRequestTracingCallback?,
+    val networkTimeout: Int,
+    val networkConnectTimeout: Int,
+    val retryCount: Int,
+    val retryInterval: Int,
+    val noConnectionRetryMax: Int,
+    val remoteInterface: BranchRemoteInterface?,
+    val attributionLevel: Defines.BranchAttributionLevel?,
+    val dmaParameters: DMAParameters?,
+    val limitFacebookAttribution: Boolean,
+    val adNetworkCalloutsDisabled: Boolean,
+    val facebookAppId: String?,
+    val preinstallCampaign: String?,
+    val preinstallPartner: String?,
+    val installMetadata: Map<String, String>,
+    val referringLinkAttributionForPreinstalledApps: Boolean,
+    val whitelistedSchemes: List<String>,
+    val uriHostsToSkip: List<String>,
+    val automaticOpenEvents: Boolean,
+    val userAgentFetchSync: Boolean
+) {
+
+    class Builder(private val branchKey: String) {
+        private var testMode: Boolean = false
+        private var apiUrl: String? = null
+        private var cdnBaseUrl: String? = null
+        private var euEndpoint: Boolean = false
+        private var logLevel: BranchLogger.BranchLogLevel = BranchLogger.BranchLogLevel.ERROR
+        private var loggingCallback: IBranchLoggingCallbacks? = null
+        private var requestTracingCallback: IBranchRequestTracingCallback? = null
+        private var networkTimeout: Int = PrefHelper.TIMEOUT
+        private var networkConnectTimeout: Int = PrefHelper.CONNECT_TIMEOUT
+        private var retryCount: Int = PrefHelper.MAX_RETRIES
+        private var retryInterval: Int = 1000 // mirrors PrefHelper.INTERVAL_RETRY
+        private var noConnectionRetryMax: Int = PrefHelper.DEFAULT_NO_CONNECTION_RETRY_MAX
+        private var remoteInterface: BranchRemoteInterface? = null
+        private var attributionLevel: Defines.BranchAttributionLevel? = null
+        private var dmaParameters: DMAParameters? = null
+        private var limitFacebookAttribution: Boolean = false
+        private var adNetworkCalloutsDisabled: Boolean = false
+        private var facebookAppId: String? = null
+        private var preinstallCampaign: String? = null
+        private var preinstallPartner: String? = null
+        private val installMetadata: MutableMap<String, String> = mutableMapOf()
+        private var referringLinkAttributionForPreinstalledApps: Boolean = false
+        private val whitelistedSchemes: MutableList<String> = mutableListOf()
+        private val uriHostsToSkip: MutableList<String> = mutableListOf()
+        private var automaticOpenEvents: Boolean = true
+        private var userAgentFetchSync: Boolean = false
+
+        // Identity & environment
+        fun setTestMode(enabled: Boolean) = apply { testMode = enabled }
+        fun setApiUrl(url: String) = apply { apiUrl = url }
+        fun setCdnBaseUrl(url: String) = apply { cdnBaseUrl = url }
+        fun setEUEndpoint(enabled: Boolean) = apply { euEndpoint = enabled }
+
+        // Logging
+        fun setLogLevel(level: BranchLogger.BranchLogLevel) = apply { logLevel = level }
+        fun setLoggingCallback(callback: IBranchLoggingCallbacks?) = apply { loggingCallback = callback }
+        fun setRequestTracingCallback(callback: IBranchRequestTracingCallback?) = apply { requestTracingCallback = callback }
+
+        // Network
+        fun setNetworkTimeout(timeoutMs: Int) = apply { networkTimeout = timeoutMs }
+        fun setNetworkConnectTimeout(timeoutMs: Int) = apply { networkConnectTimeout = timeoutMs }
+        fun setRetryCount(count: Int) = apply { retryCount = count }
+        fun setRetryInterval(intervalMs: Int) = apply { retryInterval = intervalMs }
+        fun setNoConnectionRetryMax(max: Int) = apply { noConnectionRetryMax = max }
+        fun setRemoteInterface(remoteInterface: BranchRemoteInterface?) = apply { this.remoteInterface = remoteInterface }
+
+        // Privacy & attribution
+        fun setAttributionLevel(level: Defines.BranchAttributionLevel) = apply { attributionLevel = level }
+        fun setDMAParameters(params: DMAParameters) = apply { dmaParameters = params }
+        fun setLimitFacebookAttribution(limit: Boolean) = apply { limitFacebookAttribution = limit }
+        fun setAdNetworkCalloutsDisabled(disabled: Boolean) = apply { adNetworkCalloutsDisabled = disabled }
+
+        // Install attribution
+        fun setFacebookAppId(appId: String) = apply { facebookAppId = appId }
+        fun setPreinstallCampaign(campaign: String) = apply { preinstallCampaign = campaign }
+        fun setPreinstallPartner(partner: String) = apply { preinstallPartner = partner }
+        fun addInstallMetadata(key: String, value: String) = apply { installMetadata[key] = value }
+        fun setReferringLinkAttributionForPreinstalledApps(enabled: Boolean) = apply {
+            referringLinkAttributionForPreinstalledApps = enabled
+        }
+
+        // URL collection
+        fun addWhitelistedScheme(scheme: String) = apply { whitelistedSchemes.add(scheme) }
+        fun addUriHostToSkip(host: String) = apply { uriHostsToSkip.add(host) }
+
+        // Open tracking
+        /** When false, [ProcessLifecycleOwner] won't call [Branch.sendOpen] automatically on ON_START. */
+        fun setAutomaticOpenEvents(enabled: Boolean) = apply { automaticOpenEvents = enabled }
+        fun setUserAgentFetchSync(sync: Boolean) = apply { userAgentFetchSync = sync }
+
+        /** @throws IllegalArgumentException if any field fails validation. */
+        fun build(): BranchConfiguration {
+            require(branchKey.isNotBlank()) {
+                "Branch key cannot be empty. Get your key from dashboard.branch.io/settings."
+            }
+            require(networkTimeout > 0) {
+                "Network timeout must be a positive number of milliseconds (got $networkTimeout)."
+            }
+            require(networkTimeout <= 60_000) {
+                "Network timeout cannot exceed 60 seconds / 60000 ms (got $networkTimeout)."
+            }
+            require(networkConnectTimeout > 0) {
+                "Network connect timeout must be a positive number of milliseconds (got $networkConnectTimeout)."
+            }
+            require(networkConnectTimeout <= 60_000) {
+                "Network connect timeout cannot exceed 60 seconds / 60000 ms (got $networkConnectTimeout)."
+            }
+            require(retryCount >= 0) {
+                "Retry count must be >= 0 (got $retryCount)."
+            }
+
+            return BranchConfiguration(
+                branchKey = branchKey,
+                testMode = testMode,
+                apiUrl = apiUrl,
+                cdnBaseUrl = cdnBaseUrl,
+                euEndpoint = euEndpoint,
+                logLevel = logLevel,
+                loggingCallback = loggingCallback,
+                requestTracingCallback = requestTracingCallback,
+                networkTimeout = networkTimeout,
+                networkConnectTimeout = networkConnectTimeout,
+                retryCount = retryCount,
+                retryInterval = retryInterval,
+                noConnectionRetryMax = noConnectionRetryMax,
+                remoteInterface = remoteInterface,
+                attributionLevel = attributionLevel,
+                dmaParameters = dmaParameters,
+                limitFacebookAttribution = limitFacebookAttribution,
+                adNetworkCalloutsDisabled = adNetworkCalloutsDisabled,
+                facebookAppId = facebookAppId,
+                preinstallCampaign = preinstallCampaign,
+                preinstallPartner = preinstallPartner,
+                installMetadata = installMetadata.toMap(),
+                referringLinkAttributionForPreinstalledApps = referringLinkAttributionForPreinstalledApps,
+                whitelistedSchemes = whitelistedSchemes.toList(),
+                uriHostsToSkip = uriHostsToSkip.toList(),
+                automaticOpenEvents = automaticOpenEvents,
+                userAgentFetchSync = userAgentFetchSync
+            )
+        }
+    }
+}

--- a/Branch-SDK/src/main/java/io/branch/referral/DMAParameters.kt
+++ b/Branch-SDK/src/main/java/io/branch/referral/DMAParameters.kt
@@ -1,0 +1,8 @@
+package io.branch.referral
+
+/** DMA consent fields for EEA region. Pass to [BranchConfiguration.Builder.setDMAParameters]. */
+data class DMAParameters(
+    val eeaRegion: Boolean,
+    val adPersonalizationConsent: Boolean,
+    val adUserDataUsageConsent: Boolean
+)

--- a/Branch-SDK/src/test/java/io/branch/referral/BranchConfigurationBuilderTest.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/BranchConfigurationBuilderTest.kt
@@ -1,0 +1,385 @@
+package io.branch.referral
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [BranchConfiguration.Builder] — covers builder defaults, field round-trips,
+ * build() validation rules, and the companion factory methods.
+ *
+ * All tests are pure JVM (no Android framework needed).
+ */
+class BranchConfigurationBuilderTest {
+
+    // -----------------------------------------------------------------------------------------
+    // Defaults
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun `build with only key uses expected defaults`() {
+        val config = BranchConfiguration.Builder("key_live_abc").build()
+
+        assertEquals("key_live_abc", config.branchKey)
+        assertFalse(config.testMode)
+        assertNull(config.apiUrl)
+        assertNull(config.cdnBaseUrl)
+        assertFalse(config.euEndpoint)
+        assertEquals(BranchLogger.BranchLogLevel.ERROR, config.logLevel)
+        assertNull(config.loggingCallback)
+        assertNull(config.requestTracingCallback)
+        assertEquals(PrefHelper.TIMEOUT, config.networkTimeout)
+        assertEquals(PrefHelper.CONNECT_TIMEOUT, config.networkConnectTimeout)
+        assertEquals(PrefHelper.MAX_RETRIES, config.retryCount)
+        assertNull(config.remoteInterface)
+        assertNull(config.attributionLevel)
+        assertNull(config.dmaParameters)
+        assertFalse(config.limitFacebookAttribution)
+        assertFalse(config.adNetworkCalloutsDisabled)
+        assertNull(config.facebookAppId)
+        assertNull(config.preinstallCampaign)
+        assertNull(config.preinstallPartner)
+        assertTrue(config.installMetadata.isEmpty())
+        assertFalse(config.referringLinkAttributionForPreinstalledApps)
+        assertTrue(config.whitelistedSchemes.isEmpty())
+        assertTrue(config.uriHostsToSkip.isEmpty())
+        assertTrue(config.automaticOpenEvents)
+        assertFalse(config.userAgentFetchSync)
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Field round-trips
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun `setTestMode is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x").setTestMode(true).build()
+        assertTrue(config.testMode)
+    }
+
+    @Test
+    fun `setApiUrl is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x").setApiUrl("https://custom.api.io/").build()
+        assertEquals("https://custom.api.io/", config.apiUrl)
+    }
+
+    @Test
+    fun `setCdnBaseUrl is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x").setCdnBaseUrl("https://cdn.custom.io/").build()
+        assertEquals("https://cdn.custom.io/", config.cdnBaseUrl)
+    }
+
+    @Test
+    fun `setEUEndpoint true is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x").setEUEndpoint(true).build()
+        assertTrue(config.euEndpoint)
+    }
+
+    @Test
+    fun `setLogLevel is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x")
+            .setLogLevel(BranchLogger.BranchLogLevel.VERBOSE)
+            .build()
+        assertEquals(BranchLogger.BranchLogLevel.VERBOSE, config.logLevel)
+    }
+
+    @Test
+    fun `setNetworkTimeout is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x").setNetworkTimeout(10_000).build()
+        assertEquals(10_000, config.networkTimeout)
+    }
+
+    @Test
+    fun `setNetworkConnectTimeout is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x").setNetworkConnectTimeout(3_000).build()
+        assertEquals(3_000, config.networkConnectTimeout)
+    }
+
+    @Test
+    fun `setRetryCount is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x").setRetryCount(5).build()
+        assertEquals(5, config.retryCount)
+    }
+
+    @Test
+    fun `setRetryInterval is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x").setRetryInterval(2_000).build()
+        assertEquals(2_000, config.retryInterval)
+    }
+
+    @Test
+    fun `setNoConnectionRetryMax is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x").setNoConnectionRetryMax(5).build()
+        assertEquals(5, config.noConnectionRetryMax)
+    }
+
+    @Test
+    fun `setAttributionLevel is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x")
+            .setAttributionLevel(Defines.BranchAttributionLevel.MINIMAL)
+            .build()
+        assertEquals(Defines.BranchAttributionLevel.MINIMAL, config.attributionLevel)
+    }
+
+    @Test
+    fun `setDMAParameters is stored`() {
+        val dma = DMAParameters(
+            eeaRegion = true,
+            adPersonalizationConsent = false,
+            adUserDataUsageConsent = true
+        )
+        val config = BranchConfiguration.Builder("key_live_x").setDMAParameters(dma).build()
+        assertNotNull(config.dmaParameters)
+        assertEquals(dma, config.dmaParameters)
+    }
+
+    @Test
+    fun `setLimitFacebookAttribution true is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x").setLimitFacebookAttribution(true).build()
+        assertTrue(config.limitFacebookAttribution)
+    }
+
+    @Test
+    fun `setAdNetworkCalloutsDisabled true is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x").setAdNetworkCalloutsDisabled(true).build()
+        assertTrue(config.adNetworkCalloutsDisabled)
+    }
+
+    @Test
+    fun `setFacebookAppId is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x").setFacebookAppId("fb123").build()
+        assertEquals("fb123", config.facebookAppId)
+    }
+
+    @Test
+    fun `setPreinstallCampaign is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x").setPreinstallCampaign("organic").build()
+        assertEquals("organic", config.preinstallCampaign)
+    }
+
+    @Test
+    fun `setPreinstallPartner is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x").setPreinstallPartner("samsung").build()
+        assertEquals("samsung", config.preinstallPartner)
+    }
+
+    @Test
+    fun `addInstallMetadata accumulates entries`() {
+        val config = BranchConfiguration.Builder("key_live_x")
+            .addInstallMetadata("store", "galaxy_store")
+            .addInstallMetadata("campaign", "q1")
+            .build()
+        assertEquals("galaxy_store", config.installMetadata["store"])
+        assertEquals("q1", config.installMetadata["campaign"])
+        assertEquals(2, config.installMetadata.size)
+    }
+
+    @Test
+    fun `addInstallMetadata overwrites duplicate key`() {
+        val config = BranchConfiguration.Builder("key_live_x")
+            .addInstallMetadata("store", "first")
+            .addInstallMetadata("store", "second")
+            .build()
+        assertEquals("second", config.installMetadata["store"])
+        assertEquals(1, config.installMetadata.size)
+    }
+
+    @Test
+    fun `setReferringLinkAttributionForPreinstalledApps true is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x")
+            .setReferringLinkAttributionForPreinstalledApps(true)
+            .build()
+        assertTrue(config.referringLinkAttributionForPreinstalledApps)
+    }
+
+    @Test
+    fun `addWhitelistedScheme accumulates schemes`() {
+        val config = BranchConfiguration.Builder("key_live_x")
+            .addWhitelistedScheme("myapp://")
+            .addWhitelistedScheme("otherapp://")
+            .build()
+        assertEquals(listOf("myapp://", "otherapp://"), config.whitelistedSchemes)
+    }
+
+    @Test
+    fun `addUriHostToSkip accumulates hosts`() {
+        val config = BranchConfiguration.Builder("key_live_x")
+            .addUriHostToSkip("internal.example.com")
+            .addUriHostToSkip("skip.example.com")
+            .build()
+        assertEquals(listOf("internal.example.com", "skip.example.com"), config.uriHostsToSkip)
+    }
+
+    @Test
+    fun `setAutomaticOpenEvents false is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x").setAutomaticOpenEvents(false).build()
+        assertFalse(config.automaticOpenEvents)
+    }
+
+    @Test
+    fun `setUserAgentFetchSync true is stored`() {
+        val config = BranchConfiguration.Builder("key_live_x").setUserAgentFetchSync(true).build()
+        assertTrue(config.userAgentFetchSync)
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // build() returns immutable copies of mutable collections
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun `installMetadata is immutable after build`() {
+        val builder = BranchConfiguration.Builder("key_live_x").addInstallMetadata("k", "v")
+        val config = builder.build()
+        // Modifying builder after build does not affect the config
+        builder.addInstallMetadata("k2", "v2")
+        assertFalse(config.installMetadata.containsKey("k2"))
+    }
+
+    @Test
+    fun `whitelistedSchemes is immutable after build`() {
+        val builder = BranchConfiguration.Builder("key_live_x").addWhitelistedScheme("myapp://")
+        val config = builder.build()
+        builder.addWhitelistedScheme("other://")
+        assertEquals(1, config.whitelistedSchemes.size)
+    }
+
+    @Test
+    fun `uriHostsToSkip is immutable after build`() {
+        val builder = BranchConfiguration.Builder("key_live_x").addUriHostToSkip("a.com")
+        val config = builder.build()
+        builder.addUriHostToSkip("b.com")
+        assertEquals(1, config.uriHostsToSkip.size)
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // build() validation — Branch key
+    // -----------------------------------------------------------------------------------------
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `empty branch key throws IllegalArgumentException`() {
+        BranchConfiguration.Builder("").build()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `blank branch key throws IllegalArgumentException`() {
+        BranchConfiguration.Builder("   ").build()
+    }
+
+    @Test
+    fun `empty key error message mentions dashboard`() {
+        val ex = runCatching { BranchConfiguration.Builder("").build() }
+            .exceptionOrNull() as? IllegalArgumentException
+        assertNotNull(ex)
+        assertTrue(ex!!.message!!.contains("dashboard"))
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // build() validation — network timeout
+    // -----------------------------------------------------------------------------------------
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `zero network timeout throws`() {
+        BranchConfiguration.Builder("key_live_x").setNetworkTimeout(0).build()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `negative network timeout throws`() {
+        BranchConfiguration.Builder("key_live_x").setNetworkTimeout(-1).build()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `network timeout exceeding 60s throws`() {
+        BranchConfiguration.Builder("key_live_x").setNetworkTimeout(60_001).build()
+    }
+
+    @Test
+    fun `network timeout of exactly 60s is accepted`() {
+        val config = BranchConfiguration.Builder("key_live_x").setNetworkTimeout(60_000).build()
+        assertEquals(60_000, config.networkTimeout)
+    }
+
+    @Test
+    fun `network timeout error message includes invalid value`() {
+        val ex = runCatching {
+            BranchConfiguration.Builder("key_live_x").setNetworkTimeout(-500).build()
+        }.exceptionOrNull() as? IllegalArgumentException
+        assertNotNull(ex)
+        assertTrue(ex!!.message!!.contains("-500"))
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // build() validation — connect timeout
+    // -----------------------------------------------------------------------------------------
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `zero connect timeout throws`() {
+        BranchConfiguration.Builder("key_live_x").setNetworkConnectTimeout(0).build()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `negative connect timeout throws`() {
+        BranchConfiguration.Builder("key_live_x").setNetworkConnectTimeout(-100).build()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `connect timeout exceeding 60s throws`() {
+        BranchConfiguration.Builder("key_live_x").setNetworkConnectTimeout(61_000).build()
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // build() validation — retry count
+    // -----------------------------------------------------------------------------------------
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `negative retry count throws`() {
+        BranchConfiguration.Builder("key_live_x").setRetryCount(-1).build()
+    }
+
+    @Test
+    fun `zero retry count is accepted`() {
+        val config = BranchConfiguration.Builder("key_live_x").setRetryCount(0).build()
+        assertEquals(0, config.retryCount)
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Builder chaining
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun `all setters return the builder for chaining`() {
+        // Verifies that the fluent API compiles and produces a valid config
+        val config = BranchConfiguration.Builder("key_live_x")
+            .setTestMode(true)
+            .setApiUrl("https://api.example.com/")
+            .setCdnBaseUrl("https://cdn.example.com/")
+            .setEUEndpoint(false)
+            .setLogLevel(BranchLogger.BranchLogLevel.DEBUG)
+            .setNetworkTimeout(15_000)
+            .setNetworkConnectTimeout(5_000)
+            .setRetryCount(3)
+            .setRetryInterval(1_500)
+            .setNoConnectionRetryMax(2)
+            .setAttributionLevel(Defines.BranchAttributionLevel.FULL)
+            .setDMAParameters(DMAParameters(eeaRegion = true, adPersonalizationConsent = true, adUserDataUsageConsent = false))
+            .setLimitFacebookAttribution(true)
+            .setAdNetworkCalloutsDisabled(false)
+            .setFacebookAppId("fb999")
+            .setPreinstallCampaign("spring")
+            .setPreinstallPartner("samsung")
+            .addInstallMetadata("source", "oem")
+            .setReferringLinkAttributionForPreinstalledApps(true)
+            .addWhitelistedScheme("example://")
+            .addUriHostToSkip("skip.example.com")
+            .setAutomaticOpenEvents(false)
+            .setUserAgentFetchSync(true)
+            .build()
+
+        assertEquals("key_live_x", config.branchKey)
+        assertTrue(config.testMode)
+        assertEquals(Defines.BranchAttributionLevel.FULL, config.attributionLevel)
+        assertFalse(config.automaticOpenEvents)
+    }
+}

--- a/Branch-SDK/src/test/java/io/branch/referral/BranchInitializeTest.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/BranchInitializeTest.kt
@@ -1,0 +1,242 @@
+package io.branch.referral
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * Tests for [Branch.initialize] and its private helpers [applyConfiguration] and [applyBranchKey].
+ *
+ * These tests cover the wiring layer that was NOT covered by BranchConfigurationBuilderTest
+ * (which only verifies values inside the config object). Here we verify that calling
+ * [Branch.initialize] actually propagates each config field into PrefHelper, BranchUtil,
+ * BranchLogger, and other SDK subsystems.
+ *
+ * Branch.shutDown() in @After resets the singleton so each test starts clean.
+ */
+class BranchInitializeTest : BranchTestBase() {
+
+    private val context get() = RuntimeEnvironment.getApplication()
+
+    @Before
+    override fun setUpBase() {
+        super.setUpBase()
+        Branch.shutDown()
+    }
+
+    @After
+    override fun tearDownBase() {
+        super.tearDownBase()
+        Branch.shutDown()
+    }
+
+    // -------------------------------------------------------------------------
+    // Network settings wired to PrefHelper
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun initialize_networkTimeout_reachesPrefHelper() {
+        val config = BranchConfiguration.Builder("key_live_test123")
+            .setNetworkTimeout(15_000)
+            .build()
+
+        Branch.initialize(context, config)
+
+        assertEquals(15_000, PrefHelper.getInstance(context).getTimeout())
+    }
+
+    @Test
+    fun initialize_networkConnectTimeout_reachesPrefHelper() {
+        val config = BranchConfiguration.Builder("key_live_test123")
+            .setNetworkConnectTimeout(4_000)
+            .build()
+
+        Branch.initialize(context, config)
+
+        assertEquals(4_000, PrefHelper.getInstance(context).getConnectTimeout())
+    }
+
+    @Test
+    fun initialize_retryCount_reachesPrefHelper() {
+        val config = BranchConfiguration.Builder("key_live_test123")
+            .setRetryCount(5)
+            .build()
+
+        Branch.initialize(context, config)
+
+        assertEquals(5, PrefHelper.getInstance(context).getRetryCount())
+    }
+
+    @Test
+    fun initialize_retryInterval_reachesPrefHelper() {
+        val config = BranchConfiguration.Builder("key_live_test123")
+            .setRetryInterval(2_000)
+            .build()
+
+        Branch.initialize(context, config)
+
+        assertEquals(2_000, PrefHelper.getInstance(context).getRetryInterval())
+    }
+
+    @Test
+    fun initialize_noConnectionRetryMax_reachesPrefHelper() {
+        val config = BranchConfiguration.Builder("key_live_test123")
+            .setNoConnectionRetryMax(4)
+            .build()
+
+        Branch.initialize(context, config)
+
+        assertEquals(4, PrefHelper.getInstance(context).getNoConnectionRetryMax())
+    }
+
+    // -------------------------------------------------------------------------
+    // Test mode wired to BranchUtil
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun initialize_testModeTrue_setsTestModeInBranchUtil() {
+        val config = BranchConfiguration.Builder("key_test_abc123")
+            .setTestMode(true)
+            .build()
+
+        Branch.initialize(context, config)
+
+        assertTrue(BranchUtil.isTestModeEnabled())
+    }
+
+    @Test
+    fun initialize_testModeFalse_doesNotEnableTestMode() {
+        val config = BranchConfiguration.Builder("key_live_test123")
+            .setTestMode(false)
+            .build()
+
+        Branch.initialize(context, config)
+
+        assertFalse(BranchUtil.isTestModeEnabled())
+    }
+
+    // -------------------------------------------------------------------------
+    // Log level wired to BranchLogger
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun initialize_explicitLogLevel_reachesBranchLogger() {
+        val config = BranchConfiguration.Builder("key_live_test123")
+            .setLogLevel(BranchLogger.BranchLogLevel.ERROR)
+            .build()
+
+        Branch.initialize(context, config)
+
+        assertEquals(BranchLogger.BranchLogLevel.ERROR, BranchLogger.loggingLevel)
+    }
+
+    @Test
+    fun initialize_defaultLogLevel_setsWarn() {
+        // initialize() must always own the logger state — no inherited ambient level.
+        BranchLogger.loggingLevel = BranchLogger.BranchLogLevel.VERBOSE // simulate prior state
+
+        Branch.initialize(context, BranchConfiguration.Builder("key_live_test123").build())
+
+        assertEquals(BranchLogger.BranchLogLevel.ERROR, BranchLogger.loggingLevel)
+    }
+
+    // -------------------------------------------------------------------------
+    // DMA parameters wired to PrefHelper
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun initialize_dmaParameters_eeaRegion_reachesPrefHelper() {
+        val config = BranchConfiguration.Builder("key_live_test123")
+            .setDMAParameters(DMAParameters(eeaRegion = true, adPersonalizationConsent = false, adUserDataUsageConsent = false))
+            .build()
+
+        Branch.initialize(context, config)
+
+        assertTrue(PrefHelper.getInstance(context).getEEARegion())
+    }
+
+    @Test
+    fun initialize_dmaParameters_adPersonalizationConsent_reachesPrefHelper() {
+        val config = BranchConfiguration.Builder("key_live_test123")
+            .setDMAParameters(DMAParameters(eeaRegion = false, adPersonalizationConsent = true, adUserDataUsageConsent = false))
+            .build()
+
+        Branch.initialize(context, config)
+
+        assertTrue(PrefHelper.getInstance(context).getAdPersonalizationConsent())
+    }
+
+    @Test
+    fun initialize_dmaParameters_adUserDataUsageConsent_reachesPrefHelper() {
+        val config = BranchConfiguration.Builder("key_live_test123")
+            .setDMAParameters(DMAParameters(eeaRegion = false, adPersonalizationConsent = false, adUserDataUsageConsent = true))
+            .build()
+
+        Branch.initialize(context, config)
+
+        assertTrue(PrefHelper.getInstance(context).getAdUserDataUsageConsent())
+    }
+
+    @Test
+    fun initialize_noDmaParameters_leavesEeaRegionFalse() {
+        val config = BranchConfiguration.Builder("key_live_test123").build()
+
+        Branch.initialize(context, config)
+
+        assertFalse(PrefHelper.getInstance(context).getEEARegion())
+    }
+
+    // -------------------------------------------------------------------------
+    // Branch key wired to PrefHelper (applyBranchKey)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun initialize_branchKey_reachesPrefHelper() {
+        val config = BranchConfiguration.Builder("key_live_test123").build()
+
+        Branch.initialize(context, config)
+
+        assertEquals("key_live_test123", PrefHelper.getInstance(context).getBranchKey())
+    }
+
+    // -------------------------------------------------------------------------
+    // Singleton guard — second initialize() call is a no-op
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun initialize_calledTwice_doesNotReinitialize() {
+        val first  = BranchConfiguration.Builder("key_live_first").setNetworkTimeout(5_000).build()
+        val second = BranchConfiguration.Builder("key_live_second").setNetworkTimeout(9_000).build()
+
+        Branch.initialize(context, first)
+        Branch.initialize(context, second) // should be ignored
+
+        // First call's key and timeout must survive.
+        assertEquals("key_live_first", PrefHelper.getInstance(context).getBranchKey())
+        assertEquals(5_000, PrefHelper.getInstance(context).getTimeout())
+    }
+
+    // -------------------------------------------------------------------------
+    // getInstance returns the singleton after initialize
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun initialize_then_getInstanceReturnsNonNull() {
+        val config = BranchConfiguration.Builder("key_live_test123").build()
+
+        Branch.initialize(context, config)
+
+        assertNotNull(Branch.getInstance())
+    }
+
+    @Test
+    fun beforeInitialize_getInstanceReturnsNull() {
+        assertNull(Branch.getInstance())
+    }
+}

--- a/Branch-SDK/src/test/java/io/branch/referral/DMAParametersTest.kt
+++ b/Branch-SDK/src/test/java/io/branch/referral/DMAParametersTest.kt
@@ -1,0 +1,58 @@
+package io.branch.referral
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class DMAParametersTest {
+
+    @Test
+    fun `fields are stored as supplied`() {
+        val params = DMAParameters(
+            eeaRegion = true,
+            adPersonalizationConsent = false,
+            adUserDataUsageConsent = true
+        )
+        assertEquals(true, params.eeaRegion)
+        assertEquals(false, params.adPersonalizationConsent)
+        assertEquals(true, params.adUserDataUsageConsent)
+    }
+
+    @Test
+    fun `data class equality holds for identical values`() {
+        val a = DMAParameters(eeaRegion = true, adPersonalizationConsent = true, adUserDataUsageConsent = true)
+        val b = DMAParameters(eeaRegion = true, adPersonalizationConsent = true, adUserDataUsageConsent = true)
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `data class equality distinguishes different values`() {
+        val a = DMAParameters(eeaRegion = true,  adPersonalizationConsent = false, adUserDataUsageConsent = false)
+        val b = DMAParameters(eeaRegion = false, adPersonalizationConsent = false, adUserDataUsageConsent = false)
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `copy produces independent instance with changed field`() {
+        val original = DMAParameters(eeaRegion = true, adPersonalizationConsent = true, adUserDataUsageConsent = true)
+        val copy = original.copy(adPersonalizationConsent = false)
+
+        assertEquals(true, copy.eeaRegion)
+        assertEquals(false, copy.adPersonalizationConsent)
+        assertEquals(true, copy.adUserDataUsageConsent)
+        // original is unchanged
+        assertEquals(true, original.adPersonalizationConsent)
+    }
+
+    @Test
+    fun `all false values are stored correctly`() {
+        val params = DMAParameters(
+            eeaRegion = false,
+            adPersonalizationConsent = false,
+            adUserDataUsageConsent = false
+        )
+        assertEquals(false, params.eeaRegion)
+        assertEquals(false, params.adPersonalizationConsent)
+        assertEquals(false, params.adUserDataUsageConsent)
+    }
+}


### PR DESCRIPTION
## Reference
SDK-XXX -- <TITLE>.

 Introduces the new public pre-init API to consolidate configuration settings.
  
  ### Changes

  **`DMAParameters`** (new) — Kotlin data class replacing `setDMAParamsForEEA(bool,bool,bool)` with named fields.

  **`BranchConfiguration`** (new) — Immutable config object with a `Builder` covering all pre-init settings: logging, network, privacy/attribution, install
  attribution, URL collection, and open tracking.

  **`Branch.initialize(Context, BranchConfiguration)`** (new) — Single canonical init entry point. Replaces `getAutoInstance`. Always owns SDK state on
  startup — log level defaults to `ERROR` per Android library guidelines.

  All pre-init scattered setters annotated `@Deprecated` with Javadoc pointing to the equivalent builder method. Removal targeted for next major release.

  ### Tests
  - `DMAParametersTest` — field storage, equality, copy independence
  - `BranchConfigurationBuilderTest` — defaults, field round-trips, validation
  - `BranchInitializeTest` — wiring layer: verifies each config field reaches PrefHelper/BranchLogger/BranchUtil after `initialize()` is called
  - `BranchConfigurationIntegrationTest` — on-device smoke test confirming PrefHelper wiring and logging output
- [x] I, the PR creator, have tested — integration, unit, or otherwise — this code.

## Reviewer Checklist (To be checked off by the reviewer only)

- [ ] JIRA Ticket is referenced in PR title.
- Correctness & Style
    - [ ] Conforms to [AOSP Style Guides](https://source.android.com/setup/contribute/code-style)
    - [ ] Mission critical pieces are documented in code and out of code as needed.
- [ ] Unit Tests reviewed and test issue sufficiently.
- [ ] Functionality was reviewed in QA independently by another engineer on the team.

cc @BranchMetrics/saas-sdk-devs for visibility.
